### PR TITLE
truncate: fixes handling strings shorter than truncate length

### DIFF
--- a/lib/truncate.js
+++ b/lib/truncate.js
@@ -9,6 +9,8 @@ module.exports = function(str, options) {
   var separator = options.separator;
   var omissionLength = omission.length;
 
+  if (str.length < length) return str;
+
   if (separator) {
     var words = str.split(separator);
     var word = '';

--- a/test/scripts/truncate.js
+++ b/test/scripts/truncate.js
@@ -10,6 +10,11 @@ describe('truncate', function() {
       .should.eql('Once upon a time in a world...');
   });
 
+  it('shorter string', function() {
+    truncate('Once upon')
+      .should.eql('Once upon');
+  });
+
   it('truncate', function() {
     truncate('Once upon a time in a world far far away', {length: 17})
       .should.eql('Once upon a ti...');


### PR DESCRIPTION
With this fix the function truncate is more generic. It handles cases when the string length is shorter than the truncate length in that case omission characters should not be added since they are displaying in full.