### PR TITLE
change divs in code blocks back to spans

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -32,10 +32,10 @@ function highlightUtil(str, options) {
   for (var i = 0, len = lines.length; i < len; i++) {
     line = lines[i];
     if (tab) line = replaceTabs(line, tab);
-    numbers += '<div class="line">' + (firstLine + i) + '</div>';
-    content += '<div class="line';
+    numbers += '<span class="line">' + (firstLine + i) + '</span><br>';
+    content += '<span class="line';
     content += (mark.indexOf(firstLine + i) !== -1) ? ' marked' : '';
-    content += '">' + line + '</div>';
+    content += '">' + line + '</span><br>';
   }
 
   result += '<figure class="highlight' + (data.language ? ' ' + data.language : '') + '">';

--- a/test/scripts/highlight.js
+++ b/test/scripts/highlight.js
@@ -25,7 +25,7 @@ function gutter(start, end) {
   var result = gutterStart;
 
   for (var i = start; i <= end; i++) {
-    result += '<div class="line">' + i + '</div>';
+    result += '<span class="line">' + i + '</span><br>';
   }
 
   result += gutterEnd;
@@ -46,7 +46,7 @@ function code(str, lang) {
   var result = codeStart;
 
   for (var i = 0, len = lines.length; i < len; i++) {
-    result += '<div class="line">' + lines[i] + '</div>';
+    result += '<span class="line">' + lines[i] + '</span><br>';
   }
 
   result += codeEnd;


### PR DESCRIPTION
For some reason I changed the spans to divs in a PR six months ago. Here's the fix to get rid of those divs again. Thanks to @csarron for letting me know the issue
