### PR TITLE
BugFix: Correct highlighting of multi-line element (fix #10 and hexojs/hexo#2291)

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -94,12 +94,16 @@ function highlight(str, options) {
   var lang = options.lang;
   var autoDetect = options.hasOwnProperty('autoDetect') ? options.autoDetect : false;
 
-  if (!lang) {
-    if (autoDetect) {
-      loadAllLanguages();
-      return hljs.highlightAuto(str);
-    }
+  if (!lang && autoDetect) {
+    loadAllLanguages();
+    lang = (function() {
+      var result = hljs.highlightAuto(str);
+      if (result.relevance > 0 && result.language) return result.language;
+      return;
+    })();
+  }
 
+  if (!lang) {
     lang = 'plain';
   }
 

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -122,7 +122,18 @@ function highlight(str, options) {
 
 function tryHighlight(str, lang) {
   try {
-    return hljs.highlight(lang, str);
+    var matching = str.match(/(\r?\n)/);
+    var separator = matching ? matching[1] : '';
+    var lines = matching ? str.split(separator) : [str];
+    var result = hljs.highlight(lang, lines.shift());
+    var html = result.value;
+    while (lines.length > 0) {
+      result = hljs.highlight(lang, lines.shift(), false, result.top);
+      html += separator + result.value;
+    }
+
+    result.value = html;
+    return result;
   } catch (err) {
     return;
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chai": "^3.5.0",
     "eslint": "^2.12.0",
     "eslint-config-hexo": "^1.0.3",
+    "html-tag-validator": "^1.5.0",
     "istanbul": "^0.4.3",
     "jscs": "^3.0.4",
     "jscs-preset-hexo": "^1.0.1",

--- a/test/scripts/highlight.js
+++ b/test/scripts/highlight.js
@@ -4,6 +4,7 @@ var should = require('chai').should(); // eslint-disable-line
 var hljs = require('highlight.js');
 var Entities = require('html-entities').XmlEntities;
 var entities = new Entities();
+var validator = require('html-tag-validator');
 
 var testJson = {
   foo: 1,
@@ -68,12 +69,23 @@ function assertResult(result) {
   result.should.eql(expected);
 }
 
+function validateHtmlAsync(str, done) {
+  validator(str, function(err, ast) {
+    if (err) {
+      done(err);
+    } else {
+      done();
+    }
+  });
+}
+
 describe('highlight', function() {
   var highlight = require('../../lib/highlight');
 
-  it('default', function() {
+  it('default', function(done) {
     var result = highlight(testString);
     assertResult(result, gutter(1, 4), code(testString));
+    validateHtmlAsync(result, done);
   });
 
   it('str must be a string', function() {
@@ -84,22 +96,25 @@ describe('highlight', function() {
     }
   });
 
-  it('gutter: false', function() {
+  it('gutter: false', function(done) {
     var result = highlight(testString, {gutter: false});
     assertResult(result, code(testString));
+    validateHtmlAsync(result, done);
   });
 
-  it('wrap: false', function() {
+  it('wrap: false', function(done) {
     var result = highlight(testString, {wrap: false});
     result.should.eql(entities.encode(testString));
+    validateHtmlAsync(result, done);
   });
 
-  it('firstLine', function() {
+  it('firstLine', function(done) {
     var result = highlight(testString, {firstLine: 3});
     assertResult(result, gutter(3, 6), code(testString));
+    validateHtmlAsync(result, done);
   });
 
-  it('lang = json', function() {
+  it('lang = json', function(done) {
     var result = highlight(testString, {lang: 'json'});
 
     result.should.eql([
@@ -108,9 +123,10 @@ describe('highlight', function() {
       code(testString, 'json'),
       end
     ].join(''));
+    validateHtmlAsync(result, done);
   });
 
-  it('auto detect', function() {
+  it('auto detect', function(done) {
     var result = highlight(testString, {autoDetect: true});
 
     result.should.eql([
@@ -119,16 +135,18 @@ describe('highlight', function() {
       code(testString, 'json'),
       end
     ].join(''));
+    validateHtmlAsync(result, done);
   });
 
-  it('don\'t highlight if language not found', function() {
+  it('don\'t highlight if language not found', function(done) {
     var result = highlight('test', {lang: 'jrowiejrowi'});
     assertResult(result, gutter(1, 1), code('test'));
+    validateHtmlAsync(result, done);
   });
 
   it('don\'t highlight if parse failed');
 
-  it('caption', function() {
+  it('caption', function(done) {
     var result = highlight(testString, {
       caption: 'hello world'
     });
@@ -139,9 +157,10 @@ describe('highlight', function() {
       code(testString),
       end
     ].join(''));
+    validateHtmlAsync(result, done);
   });
 
-  it('tab', function() {
+  it('tab', function(done) {
     var str = [
       'function fib(i){',
       '\tif (i <= 1) return i;',
@@ -157,9 +176,10 @@ describe('highlight', function() {
       code(str.replace(/\t/g, '  '), 'js'),
       end
     ].join(''));
+    validateHtmlAsync(result, done);
   });
 
-  it('escape html entity', function() {
+  it('escape html entity', function(done) {
     var str = [
       'deploy:',
       '  type: git',
@@ -170,9 +190,10 @@ describe('highlight', function() {
 
     var result = highlight(str);
     result.should.include('&lt;repository url&gt;');
+    validateHtmlAsync(result, done);
   });
 
-  it('parse multi-line strings correctly', function() {
+  it('parse multi-line strings correctly', function(done) {
     var str = [
       'var string = `',
       '  Multi',
@@ -188,9 +209,10 @@ describe('highlight', function() {
       code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string">  line</span>\n<span class="string">  string</span>\n<span class="string">`</span>', null),
       end
     ].join(''));
+    validateHtmlAsync(result, done);
   });
 
-  it('parse multi-line strings including empty line', function() {
+  it('parse multi-line strings including empty line', function(done) {
     var str = [
       'var string = `',
       '  Multi',
@@ -206,9 +228,10 @@ describe('highlight', function() {
       code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null),
       end
     ].join(''));
+    validateHtmlAsync(result, done);
   });
 
-  it('auto detect of multi-line statement', function() {
+  it('auto detect of multi-line statement', function(done) {
     var str = [
       '"use strict";',
       'var string = `',
@@ -225,9 +248,10 @@ describe('highlight', function() {
       code('<span class="meta">"use strict"</span>;\n<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null),
       end
     ].join(''));
+    validateHtmlAsync(result, done);
   });
 
-  it('gives the highlight class to marked lines', function() {
+  it('gives the highlight class to marked lines', function(done) {
     var str = [
       'roses are red',
       'violets are blue',
@@ -241,5 +265,6 @@ describe('highlight', function() {
     result.should.include('class="line">violets');
     result.should.include('class="line marked">sugar');
     result.should.include('class="line">and');
+    validateHtmlAsync(result, done);
   });
 });

--- a/test/scripts/highlight.js
+++ b/test/scripts/highlight.js
@@ -208,6 +208,25 @@ describe('highlight', function() {
     ].join(''));
   });
 
+  it('auto detect of multi-line statement', function() {
+    var str = [
+      '"use strict";',
+      'var string = `',
+      '  Multi',
+      '',
+      '  string',
+      '`'
+    ].join('\n');
+
+    var result = highlight(str, {autoDetect: true});
+    result.should.eql([
+      '<figure class="highlight javascript"><table><tr>',
+      gutter(1, 6),
+      code('<span class="meta">"use strict"</span>;\n<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null),
+      end
+    ].join(''));
+  });
+
   it('gives the highlight class to marked lines', function() {
     var str = [
       'roses are red',

--- a/test/scripts/highlight.js
+++ b/test/scripts/highlight.js
@@ -38,6 +38,8 @@ function code(str, lang) {
 
   if (lang) {
     data = hljs.highlight(lang.toLowerCase(), str);
+  } else if (lang === null) {
+    data = {value: str};
   } else {
     data = {value: entities.encode(str)};
   }
@@ -183,7 +185,25 @@ describe('highlight', function() {
     result.should.eql([
       '<figure class="highlight js"><table><tr>',
       gutter(1, 5),
-      code(str, 'js'),
+      code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string">  line</span>\n<span class="string">  string</span>\n<span class="string">`</span>', null),
+      end
+    ].join(''));
+  });
+
+  it('parse multi-line strings including empty line', function() {
+    var str = [
+      'var string = `',
+      '  Multi',
+      '',
+      '  string',
+      '`'
+    ].join('\n');
+
+    var result = highlight(str, {lang: 'js'});
+    result.should.eql([
+      '<figure class="highlight js"><table><tr>',
+      gutter(1, 5),
+      code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null),
       end
     ].join(''));
   });


### PR DESCRIPTION
Correct highlighting of multi-line element (fix #10 and hexojs/hexo#2291).

This patch is similar to the patch hexojs/hexo#904 that fixed the issue hexojs/hexo#902.
But the API `highlightByLine()` is no longer supported by [highlight.js](http://highlightjs.readthedocs.io/en/latest/api.html).
So I use the API `highlight()` with continuation.

And also add HTML validation to each test case.
If this validation was implemented, the issue #10 might be detected.
For this puropose, add a new `devDependencies` for `html-tag-validator` package.    
https://www.npmjs.com/package/html-tag-validator    
https://github.com/codeschool/htmlTagValidator