### PR TITLE
Remove postinstall step

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,3 @@ coverage/
 gulpfile.js
 .idea/
 appveyor.yml
-highlight_alias.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ node_js:
   - "node"
 
 script:
+  # For older versions of npm (ie. the one bundled with Node 6), we need to manually run `prepare`
+  # to build the project. You can still install and consume the package without any issue.
+  - if [[ "$TRAVIS_NODE_VERSION" == "6" ]]; then npm run prepare; fi
   - npm run eslint
   - npm run jscs
   - npm run test-cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Next
+
+- **[Fix]** Remove postinstall step, fixes installations issues for some systems. [#24](https://github.com/hexojs/hexo-util/issues/24) 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha test/index.js",
     "test-cov": "istanbul cover --print both _mocha -- test/index.js",
     "build:highlight": "node scripts/build_highlight_alias.js > highlight_alias.json",
-    "postinstall": "npm run build:highlight"
+    "prepare": "npm run build:highlight"
   },
   "directories": {
     "lib": "./lib"
@@ -24,7 +24,7 @@
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "maintainers": [
     "Abner Chou <hi@abnerchou.me> (http://abnerchou.me)"
-    ],
+  ],
   "license": "MIT",
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Use a `prepare` hook instead of a `postinstall` hook to generate
the `highlight_alias.json` file. This means that the file is generated
during the publication of package to npm or when manually running
`npm install` in the project directory.
The previous behavior was to generate this step on the consumer
side: this was the cause of numerous hard-to-reproduce issues due
to the variety of environments.

Closes hexojs/hexo-util#20
Closes hexojs/hexo-util#23
Closes hexojs/hexo-util#24
Related to hexojs/hexo-cli#23
Related to hexojs/hexo#2095