### PR TITLE
Apply hljs classPrefix to container figure element

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Option | Description | Default
 `caption` | Caption |
 `tab`| Replace tabs |
 `autoDetect` | Detect language automatically | false
+`classPrefix` | Prefix for generated HTML's classes |
+
+If classPrefix is unset, the containing `<figure>` element will have the class
+`highlight`. Highlight.js currently uses the `hljs` prefix. This was not the case
+earlier and is the reason that the default is blank, so as to not break compatibility
+in older hexo sites.
 
 ### htmlTag(tag, attrs, text)
 

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -5,13 +5,19 @@ var Entities = require('html-entities').XmlEntities;
 var entities = new Entities();
 var alias = require('../highlight_alias.json');
 
-hljs.configure({
-  classPrefix: ''
-});
+// hljs.configure({
+//   classPrefix: ''
+// });
 
 function highlightUtil(str, options) {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
   options = options || {};
+
+  var classPrefix = options.hasOwnProperty('classPrefix') ? options.classPrefix : '';
+
+  hljs.configure({
+    classPrefix: classPrefix
+  });
 
   var gutter = options.hasOwnProperty('gutter') ? options.gutter : true;
   var wrap = options.hasOwnProperty('wrap') ? options.wrap : true;
@@ -20,12 +26,6 @@ function highlightUtil(str, options) {
   var mark = options.hasOwnProperty('mark') ? options.mark : [];
   var tab = options.tab;
   var data = highlight(str, options);
-  
-  if (options.hasOwnProperty('classPrefix')) {
-    hljs.configure({
-      classPrefix: options.classPrefix
-    });
-  }
 
   if (!wrap) return data.value;
 

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -5,10 +5,6 @@ var Entities = require('html-entities').XmlEntities;
 var entities = new Entities();
 var alias = require('../highlight_alias.json');
 
-// hljs.configure({
-//   classPrefix: ''
-// });
-
 function highlightUtil(str, options) {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
   options = options || {};

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -13,7 +13,8 @@ function highlightUtil(str, options) {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
   options = options || {};
 
-  var classPrefix = options.hasOwnProperty('classPrefix') ? options.classPrefix : '';
+  var classPrefix = options.hasOwnProperty('classPrefix') ? options.classPrefix + '-' : '';
+  var containerPrefix = options.hasOwnProperty('classPrefix') ? options.classPrefix : 'highlight';
 
   hljs.configure({
     classPrefix: classPrefix
@@ -44,7 +45,7 @@ function highlightUtil(str, options) {
     content += '">' + line + '</div>';
   }
 
-  result += '<figure class="highlight' + (data.language ? ' ' + data.language : '') + '">';
+  result += '<figure class="' + containerPrefix + (data.language ? ' ' + data.language : '') + '">';
 
   if (caption) {
     result += '<figcaption>' + caption + '</figcaption>';

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -20,6 +20,12 @@ function highlightUtil(str, options) {
   var mark = options.hasOwnProperty('mark') ? options.mark : [];
   var tab = options.tab;
   var data = highlight(str, options);
+  
+  if (options.hasOwnProperty('classPrefix')) {
+    hljs.configure({
+      classPrefix: options.classPrefix
+    });
+  }
 
   if (!wrap) return data.value;
 

--- a/test/scripts/highlight.js
+++ b/test/scripts/highlight.js
@@ -33,8 +33,14 @@ function gutter(start, end) {
   return result;
 }
 
-function code(str, lang) {
+function code(str, lang, classPrefix) {
   var data;
+
+  if (classPrefix) {
+    hljs.configure({
+      classPrefix: classPrefix
+    });
+  }
 
   if (lang) {
     data = hljs.highlight(lang.toLowerCase(), str);
@@ -202,5 +208,23 @@ describe('highlight', function() {
     result.should.include('class="line">violets');
     result.should.include('class="line marked">sugar');
     result.should.include('class="line">and');
+  });
+
+  it('can set classPrefix options', function() {
+    var str = [
+      'var a = `',
+      '  Multi',
+      '  line',
+      '  string',
+      '`'
+    ].join('\n');
+    var result = highlight(str, {lang: 'js', classPrefix: 'hljs-'});
+    result.should.eql([
+      '<figure class="highlight js"><table><tr>',
+      gutter(1, 5),
+      code(str, 'js', 'hljs-'),
+      end
+    ].join(''));
+    console.log(result);
   });
 });

--- a/test/scripts/highlight.js
+++ b/test/scripts/highlight.js
@@ -218,9 +218,9 @@ describe('highlight', function() {
       '  string',
       '`'
     ].join('\n');
-    var result = highlight(str, {lang: 'js', classPrefix: 'hljs-'});
+    var result = highlight(str, {lang: 'js', classPrefix: 'hljs'});
     result.should.eql([
-      '<figure class="highlight js"><table><tr>',
+      '<figure class="hljs js"><table><tr>',
       gutter(1, 5),
       code(str, 'js', 'hljs-'),
       end


### PR DESCRIPTION
Building on #15. As hljs uses 'hljs' by default for its containers, and not 'highlight' as hexo currently has hardcoded, this makes sure that the original hljs stylesheets maintain compatibility, should you use hljs as your parameter.

It should be noted that a `-` is appended to the class prefix so that we get, for example, `hljs` for the container and `hljs-number`. Also added some quick documentation as was requested in #15.