### PR TITLE
hljs - Added compatibility for CSS styles.

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -5,20 +5,23 @@ var Entities = require('html-entities').XmlEntities;
 var entities = new Entities();
 var alias = require('../highlight_alias.json');
 
-hljs.configure({
-  classPrefix: ''
-});
-
 function highlightUtil(str, options) {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
   options = options || {};
 
+  var useHljs = options.hasOwnProperty('hljs') ? options.hljs : false;
   var gutter = options.hasOwnProperty('gutter') ? options.gutter : true;
   var wrap = options.hasOwnProperty('wrap') ? options.wrap : true;
   var firstLine = options.hasOwnProperty('firstLine') ? +options.firstLine : 1;
   var caption = options.caption;
   var mark = options.hasOwnProperty('mark') ? options.mark : [];
   var tab = options.tab;
+
+  hljs.configure({ classPrefix: useHljs ? 'hljs-' : ''});
+  // If modern hljs support is enabled and there's no gutter, don't wrap the code block.
+  if (useHljs && !gutter) wrap = false;
+
+
   var data = highlight(str, options);
 
   if (!wrap) return data.value;
@@ -33,9 +36,7 @@ function highlightUtil(str, options) {
     line = lines[i];
     if (tab) line = replaceTabs(line, tab);
     numbers += '<span class="line">' + (firstLine + i) + '</span><br>';
-    content += '<span class="line';
-    content += (mark.indexOf(firstLine + i) !== -1) ? ' marked' : '';
-    content += '">' + line + '</span><br>';
+    content += formatLine(line, firstLine + i, mark, options);
   }
 
   result += '<figure class="highlight' + (data.language ? ' ' + data.language : '') + '">';
@@ -54,6 +55,19 @@ function highlightUtil(str, options) {
   result += '</tr></table></figure>';
 
   return result;
+}
+
+function formatLine(line, lineno, marked, options) {
+  var useHljs = options.hljs || false;
+  var res = useHljs ? '' : '<span class="line';
+  if (marked.indexOf(lineno) !== -1) {
+    // Handle marked lines.
+    res += useHljs ? '<mark>' + line + '</mark>' : ' marked">' + line + '</span>';
+  } else {
+    res += useHljs ? line : '">' + line + '</span>';
+  }
+  res += '<br>';
+  return res;
 }
 
 function encodePlainString(str) {
@@ -114,6 +128,12 @@ function highlight(str, options) {
 
   if (result.language === 'plain') {
     return result;
+  }
+
+  if (options.hljs) {
+    var res = hljs.highlight(lang, str);
+    res.value = ['<pre><code class="hljs ' + lang + '">', res.value, '</code></pre>'].join('\n');
+    return res;
   }
 
   if (!tryLanguage(result.language)) {

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -21,7 +21,6 @@ function highlightUtil(str, options) {
   // If modern hljs support is enabled and there's no gutter, don't wrap the code block.
   if (useHljs && !gutter) wrap = false;
 
-
   var data = highlight(str, options);
 
   if (!wrap) return data.value;
@@ -66,6 +65,7 @@ function formatLine(line, lineno, marked, options) {
   } else {
     res += useHljs ? line : '">' + line + '</span>';
   }
+
   res += '<br>';
   return res;
 }

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -18,12 +18,15 @@ function highlightUtil(str, options) {
   var tab = options.tab;
 
   hljs.configure({ classPrefix: useHljs ? 'hljs-' : ''});
-  // If modern hljs support is enabled and there's no gutter, don't wrap the code block.
-  if (useHljs && !gutter) wrap = false;
 
   var data = highlight(str, options);
 
-  if (!wrap) return data.value;
+  if (useHljs && !gutter) wrap = false;
+
+  var before = useHljs ? '<pre><code class="hljs ' + options.lang + '">' : '<pre>';
+  var after = useHljs ? '</code></pre>' : '</pre>';
+
+  if (!wrap) return useHljs ? before + data.value + after : data.value;
 
   var lines = data.value.split('\n');
   var numbers = '';
@@ -50,7 +53,7 @@ function highlightUtil(str, options) {
     result += '<td class="gutter"><pre>' + numbers + '</pre></td>';
   }
 
-  result += '<td class="code"><pre>' + content + '</pre></td>';
+  result += '<td class="code">' + before + content + after + '</td>';
   result += '</tr></table></figure>';
 
   return result;
@@ -130,16 +133,12 @@ function highlight(str, options) {
     return result;
   }
 
-  if (options.hljs) {
-    var res = hljs.highlight(lang, str);
-    res.value = ['<pre><code class="hljs ' + lang + '">', res.value, '</code></pre>'].join('\n');
-    return res;
-  }
-
   if (!tryLanguage(result.language)) {
     result.language = 'plain';
     return result;
   }
+
+  if (options.hljs) return hljs.highlight(lang, str);
 
   return tryHighlight(str, result.language) || result;
 }

--- a/test/scripts/highlight.js
+++ b/test/scripts/highlight.js
@@ -268,7 +268,7 @@ describe('highlight', function() {
     validateHtmlAsync(result, done);
   });
 
-  it('hljs compatibility - with lines', () => {
+  it('hljs compatibility - with lines', (done) => {
     var str = [
       'function (a) {',
       '    if (a > 3)',
@@ -281,9 +281,11 @@ describe('highlight', function() {
     result.should.include(codeStart);
     result.should.include('code class="hljs javascript"');
     result.should.include('class="hljs-function"');
+    result.should.include(gutter(1, 5));
+    validateHtmlAsync(result, done);
   });
 
-  it('hljs compatibility - no lines', () => {
+  it('hljs compatibility - no lines', (done) => {
     var str = [
       'function (a) {',
       '    if (a > 3)',
@@ -296,5 +298,6 @@ describe('highlight', function() {
     result.should.not.include(codeStart);
     result.should.include('code class="hljs javascript"');
     result.should.include('class="hljs-function"');
+    validateHtmlAsync(result, done);
   });
 });

--- a/test/scripts/highlight.js
+++ b/test/scripts/highlight.js
@@ -267,4 +267,34 @@ describe('highlight', function() {
     result.should.include('class="line">and');
     validateHtmlAsync(result, done);
   });
+
+  it('hljs compatibility - with lines', () => {
+    var str = [
+      'function (a) {',
+      '    if (a > 3)',
+      '        return true;',
+      '    return false;',
+      '}'
+    ].join('\n');
+    var result = highlight(str, {hljs: true, lang: 'javascript' });
+    result.should.include(gutterStart);
+    result.should.include(codeStart);
+    result.should.include('code class="hljs javascript"');
+    result.should.include('class="hljs-function"');
+  });
+
+  it('hljs compatibility - no lines', () => {
+    var str = [
+      'function (a) {',
+      '    if (a > 3)',
+      '        return true;',
+      '    return false;',
+      '}'
+    ].join('\n');
+    var result = highlight(str, {hljs: true, gutter: false, lang: 'javascript' });
+    result.should.not.include(gutterStart);
+    result.should.not.include(codeStart);
+    result.should.include('code class="hljs javascript"');
+    result.should.include('class="hljs-function"');
+  });
 });


### PR DESCRIPTION
This pull request adds additional support to render the highlighting with `hljs-` prefix and preserves backward compatibility for existing themes/stylesheets.

Support for both marked lines and line numbers, as well as vanilla highlight.js blocks is included.

This is a quick proof of concept that I whipped up after I started working on my theme and realizing that hljs CSS themes weren't supported. I hope it can be helpful to hexo users.

It's a two part pull request as [hexo/#2901](https://github.com/hexojs/hexo/pull/2901) adds support for propagating the `hljs` configuration through to the highlight plugin.

If everything is good (or after necessary changes), I will be updating the documentation as well to document the new config for `_config.yml`.

Cheers,