### PR TITLE
Fix sublanguages highlight

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var hljs = require('highlight.js/lib/highlight');
+var hljs = require('highlight.js');
 var Entities = require('html-entities').XmlEntities;
 var entities = new Entities();
 var alias = require('../highlight_alias.json');
@@ -89,30 +89,11 @@ function replaceTabs(str, tab) {
   });
 }
 
-function loadLanguage(lang) {
-  hljs.registerLanguage(lang, require('highlight.js/lib/languages/' + lang));
-}
-
-function tryLanguage(lang) {
-  if (hljs.getLanguage(lang)) return true;
-  if (!alias.aliases[lang]) return false;
-
-  loadLanguage(alias.aliases[lang]);
-  return true;
-}
-
-function loadAllLanguages() {
-  alias.languages.filter(function(lang) {
-    return !hljs.getLanguage(lang);
-  }).forEach(loadLanguage);
-}
-
 function highlight(str, options) {
   var lang = options.lang;
   var autoDetect = options.hasOwnProperty('autoDetect') ? options.autoDetect : false;
 
   if (!lang && autoDetect) {
-    loadAllLanguages();
     lang = (function() {
       var result = hljs.highlightAuto(str);
       if (result.relevance > 0 && result.language) return result.language;
@@ -133,7 +114,7 @@ function highlight(str, options) {
     return result;
   }
 
-  if (!tryLanguage(result.language)) {
+  if (!alias.aliases[result.language]) {
     result.language = 'plain';
     return result;
   }

--- a/test/scripts/highlight.js
+++ b/test/scripts/highlight.js
@@ -193,6 +193,18 @@ describe('highlight', function() {
     validateHtmlAsync(result, done);
   });
 
+  it('highlight sublanguages', function(done) {
+    var str = '<node><?php echo "foo"; ?></node>';
+    var result = highlight(str, {lang: 'xml'});
+    result.should.eql([
+      '<figure class="highlight xml"><table><tr>',
+      gutter(1, 1),
+      code('<span class="tag">&lt;<span class="name">node</span>&gt;</span><span class="php"><span class="meta">&lt;?php</span> <span class="keyword">echo</span> <span class="string">"foo"</span>; <span class="meta">?&gt;</span></span><span class="tag">&lt;/<span class="name">node</span>&gt;</span>', null),
+      end
+    ].join(''));
+    validateHtmlAsync(result, done);
+  });
+
   it('parse multi-line strings correctly', function(done) {
     var str = [
       'var string = `',


### PR DESCRIPTION
Highlightjs has a sublanguages feature which allows some languages to incorporate and highlight another language inside it. When I use a sublanguage in Hexo, it doesn't work:

<img width="894" alt="without_highlight" src="https://user-images.githubusercontent.com/15314293/43989876-c8073d8c-9d52-11e8-8304-5ebb321bd6ad.png">

This PR make the sublanguages functional:

<img width="894" alt="highlight" src="https://user-images.githubusercontent.com/15314293/43989895-149cff6a-9d53-11e8-8e73-9a2f2c5b0d48.png">

The sublanguage feature requires that the sublangage definition is loaded. But Hexo only load the definition of the main language of the code chunk. I suggest to always load all language definitions, like it's done in highlightjs library and in hexo-util tests (so the tests are currently not totally right since the definitions loaded in tests are not the same as the definitions actually loaded by hexo-utils).

Also, it could be possible to dynamically load sublanguages but it will make hexo-util too closely coupled with hightlighjs IMHO.