### PR TITLE
Deprecated hashStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ hash('123456');
 ```
 
 ### HashStream()
+**\[deprecated\]** use `createSha1Hash()`.
 
 Generates SHA1 hash with a transform stream.
 
@@ -77,6 +78,18 @@ fs.createReadStream('/path/to/file')
   .pipe(stream)
   .on('finish', function(){
     console.log(stream.read());
+  });
+```
+
+### createSha1Hash()
+return SHA1 hash object.
+ This is the same as calling `createHash('utf8')` in the node.js native module crypto.
+ ``` js
+const sha1 = createSha1Hash();
+ fs.createReadStream('/path/to/file')
+  .pipe(sha1)
+  .on('finish', () => {
+    console.log(sha1.read());
   });
 ```
 

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -5,10 +5,17 @@ var crypto = require('crypto');
 
 var ALGORITHM = 'sha1';
 
+function createSha1Hash() {
+  return crypto.createHash(ALGORITHM);
+}
+
+/**
+ * @deprecated
+ * createHash() is stream class.
+ */
 function HashStream() {
   Transform.call(this);
-
-  this._hash = crypto.createHash(ALGORITHM);
+  this._hash = createSha1Hash();
 }
 
 require('util').inherits(HashStream, Transform);
@@ -23,10 +30,11 @@ HashStream.prototype._flush = function(callback) {
   callback();
 };
 
-exports.hash = function(content) {
-  var hash = crypto.createHash(ALGORITHM);
+exports.hash = content => {
+  const hash = createSha1Hash();
   hash.update(content);
   return hash.digest();
 };
 
 exports.HashStream = HashStream;
+exports.createSha1Hash = createSha1Hash;

--- a/test/scripts/hash.js
+++ b/test/scripts/hash.js
@@ -27,4 +27,23 @@ describe('hash', function() {
 
     stream.read().should.eql(sha1(content));
   });
+
+  it('createSha1Hash', function() {
+    var _sha1 = hash.createSha1Hash();
+    var content = '123456';
+    _sha1.update(content);
+    _sha1.digest().should.eql(sha1(content));
+  });
+
+  it('createSha1Hash - streamMode', function() {
+    var content1 = '123456';
+    var content2 = '654321';
+    var stream = hash.createSha1Hash();
+    // explicit convert
+    stream.write(Buffer.from(content1));
+    // implicit convert
+    stream.write(content2);
+    stream.end();
+    stream.read().should.eql(sha1(content1 + content2));
+  });
 });


### PR DESCRIPTION
This PR is divided PR because #35 has become big.

`Hash` class It itself inherits the `Transform` class. There is no need to go through `HashStream`.
In addition, `HashStream` implementation does not assume `objectMode`, and `objectMode` is invalid in `Transform` options! (It is controlled by `readableObjectMode` and `writableObjectMode`)

Since the implementation was originally unclear, you can solve the problem by creating a new `createSha1Hash()` and migrating it to it.