### PR TITLE
fix: prevent firstLine being parsed as a string

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -36,8 +36,8 @@ function highlightUtil(str, options = {}) {
   for (let i = 0, len = lines.length; i < len; i++) {
     let line = lines[i];
     if (tab) line = replaceTabs(line, tab);
-    numbers += `<span class="line">${firstLine + i}</span><br>`;
-    content += formatLine(line, firstLine + i, mark, options);
+    numbers += `<span class="line">${Number(firstLine) + i}</span><br>`;
+    content += formatLine(line, Number(firstLine) + i, mark, options);
   }
 
   let result = `<figure class="highlight${data.language ? ` ${data.language}` : ''}">`;


### PR DESCRIPTION
firstLine variable sometimes can be parsed as a string.
let say, `firstLine = 1`; `firstLine + 3` can results in `13`, instead of expected `4`.

See https://github.com/hexojs/hexo/pull/3646