### PR TITLE
fix: fs.write instead of stdout

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eslint": "eslint .",
     "test": "mocha test/index.js",
     "test-cov": "nyc npm run test",
-    "build:highlight": "node scripts/build_highlight_alias.js > highlight_alias.json",
+    "build:highlight": "node scripts/build_highlight_alias.js",
     "prepare": "npm run build:highlight"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "lib/",
-    "scripts/"
+    "scripts/",
+    "highlight_alias.json"
   ],
   "repository": "hexojs/hexo-util",
   "homepage": "https://hexo.io/",

--- a/scripts/build_highlight_alias.js
+++ b/scripts/build_highlight_alias.js
@@ -2,6 +2,7 @@
 
 var hljs = require('highlight.js');
 var languages = hljs.listLanguages();
+const fs = require('fs');
 
 var result = {
   languages: languages,
@@ -21,4 +22,9 @@ languages.forEach(function(lang) {
   }
 });
 
-console.log(JSON.stringify(result));
+const stream = fs.createWriteStream('highlight_alias.json');
+stream.write(JSON.stringify(result));
+stream.on('end', () => {
+  stream.end();
+});
+


### PR DESCRIPTION
in some edge case, stdout can [be empty](https://stackoverflow.com/questions/54190596/no-console-log-to-stdout-when-running-npm-test-jest) when running npm script, i.e. `npm run prepare`. `fs.write` is more reliable.

"highlight_alias.json" should be published, it's generated when `npm publish`. The value in "files" attribute is needed even when `"hexo-util": "hexojs/hexo-util"`, otherwise it would not be generated when `npm install`.

Fixes https://github.com/hexojs/hexo/pull/3646#issuecomment-519465750, Address https://github.com/hexojs/hexo-util/pull/57#issuecomment-519031638

### How to test
`$ rm -r node_modules/`

``` diff
package.json
-  "hexo": "^3.9.0"
+  "hexo": "curbengh/hexo#rc"
```

``` bash
$ npm i
$ hexo -v # should be no error
$ npm test
```