### PR TITLE
fix: export Color function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const hash = require('./hash');
 
+exports.Color = require('./color');
 exports.escapeDiacritic = require('./escape_diacritic');
 exports.escapeHTML = require('./escape_html');
 exports.escapeRegExp = require('./escape_regexp');


### PR DESCRIPTION
Currently, using the Color function requires `const Color = require('../../../node_modules/hexo-util/lib/color');`.

It should be just `const Color = require('hexo-util').Color;`.