### PR TITLE
feat: add encodeURL()

### DIFF
--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const { parse, format } = require('url');
+
+function encodeURL(str) {
+  if (parse(str).protocol) {
+    return format({
+      protocol: parse(str).protocol,
+      hostname: parse(str).hostname,
+      pathname: encodeURI(decodeURI(parse(str).pathname))
+    });
+  }
+
+  return encodeURI(str);
+}
+
+module.exports = encodeURL;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ exports.CacheStream = require('./cache_stream');
 exports.camelCaseKeys = require('./camel_case_keys');
 exports.Color = require('./color');
 exports.createSha1Hash = hash.createSha1Hash;
+exports.encodeURL = require('./encode_url');
 exports.escapeDiacritic = require('./escape_diacritic');
 exports.escapeHTML = require('./escape_html');
 exports.escapeRegExp = require('./escape_regexp');

--- a/test/encode_url.spec.js
+++ b/test/encode_url.spec.js
@@ -1,0 +1,42 @@
+'use strict';
+
+require('chai').should();
+
+describe('encodeURL', () => {
+  const encodeURL = require('../lib/encode_url');
+
+  it('regular', () => {
+    const content = 'http://foo.com/';
+    encodeURL(content).should.eql(content);
+  });
+
+  it('space', () => {
+    const content = 'http://foo.com/bar baz';
+    encodeURL(content).should.eql('http://foo.com/bar%20baz');
+  });
+
+  it('unicode', () => {
+    const content = 'http://foo.com/bár';
+    encodeURL(content).should.eql('http://foo.com/b%C3%A1r');
+  });
+
+  it('idn', () => {
+    const content = 'http://bár.com/baz';
+    encodeURL(content).should.eql('http://xn--br-mia.com/baz');
+  });
+
+  it('path', () => {
+    const content = '/foo/bar/';
+    encodeURL(content).should.eql(content);
+  });
+
+  it('path with space', () => {
+    const content = '/foo bar/baz/';
+    encodeURL(content).should.eql('/foo%20bar/baz/');
+  });
+
+  it('path with unicode', () => {
+    const content = '/foo/bár/';
+    encodeURL(content).should.eql('/foo/b%C3%A1r/');
+  });
+});


### PR DESCRIPTION
This PR is stemmed from IDN parsing issue (https://github.com/hexojs/hexo-generator-feed/issues/63). It was later (partially) fixed in https://github.com/hexojs/hexo-generator-feed/pull/82, without encodeURI the root value. Full fix is later proposed in https://github.com/hexojs/hexo-generator-feed/pull/88.

IDN incompatibility is also found in [hexo-generator-sitemap](https://github.com/hexojs/hexo-generator-sitemap/pull/66) and [open_graph()](https://github.com/hexojs/hexo/pull/3686).

All the proposed fixes actually share similar function, so I propose to put it in hexo-util instead.