### PR TITLE
fix: readme codeblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ url_for('/css/style.css')
 
 /* Override option
  * you could also enable it to output a relative link,
- * even when `relative_link` is disabled
+ * even when `relative_link` is disabled and vice versa.
  */
 url_for('/css/style.css', {relative: false})
 // /css/style.css

--- a/README.md
+++ b/README.md
@@ -342,11 +342,13 @@ relative_link: true
 url_for('/css/style.css')
 // ../../css/style.css
 
-// Override option
-// you could also enable it to output a relative link,
-// even when `relative_link` is disabled
+/* Override option
+ * you could also enable it to output a relative link,
+ * even when `relative_link` is disabled
+ */
 url_for('/css/style.css', {relative: false})
 // /css/style.css
+```
 
 ## bind(hexo)
 


### PR DESCRIPTION
forgot to close the codeblock.
also update docs that `relative:` also works the other around.