### PR TITLE
prevent 'URI malformed' exception

### DIFF
--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -3,26 +3,35 @@
 const { parse, format } = require('url');
 
 function encodeURL(str) {
-  if (parse(str).protocol) {
+  const parsed = parse(str);
+  if (parsed.protocol) {
     const obj = Object.assign({}, {
-      auth: parse(str).auth,
-      protocol: parse(str).protocol,
-      host: parse(str).host,
-      pathname: encodeURI(decodeURI(parse(str).pathname))
+      auth: parsed.auth,
+      protocol: parsed.protocol,
+      host: parsed.host,
+      pathname: encodeURI(safeDecodeURI(parsed.pathname))
     });
 
-    if (parse(str).hash) {
-      Object.assign(obj, { hash: encodeURI(decodeURI(parse(str).hash)) });
+    if (parsed.hash) {
+      Object.assign(obj, { hash: encodeURI(safeDecodeURI(parsed.hash)) });
     }
 
-    if (parse(str).search) {
-      Object.assign(obj, { search: encodeURI(decodeURI(parse(str).search)) });
+    if (parsed.search) {
+      Object.assign(obj, { search: encodeURI(safeDecodeURI(parsed.search)) });
     }
 
     return format(obj);
   }
 
-  return encodeURI(decodeURI(str));
+  return encodeURI(safeDecodeURI(str));
+}
+
+function safeDecodeURI(str) {
+  try {
+    return decodeURI(str);
+  } catch (err) {
+    return str;
+  }
 }
 
 module.exports = encodeURL;

--- a/test/encode_url.spec.js
+++ b/test/encode_url.spec.js
@@ -45,6 +45,16 @@ describe('encodeURL', () => {
     encodeURL(content).should.eql('http://foo.com/bar?q%C3%BAery=b%C3%A1z');
   });
 
+  it('query contains %', () => {
+    const content = 'http://foo.com/bar?query=%';
+    encodeURL(content).should.eql('http://foo.com/bar?query=%25');
+  });
+
+  it('path or query contains %', () => {
+    const content = '/bar?query=%';
+    encodeURL(content).should.eql('/bar?query=%25');
+  });
+
   it('multiple queries', () => {
     const content = 'http://foo.com/bar?query1=aáa&query2=aàa';
     encodeURL(content).should.eql('http://foo.com/bar?query1=a%C3%A1a&query2=a%C3%A0a');


### PR DESCRIPTION
with #92 
In some edge case, decode a text which is not encoded by `encodeURI`, `decodeURI` will raise `URI malformed` exception.
e.g.
```js
encodeURL("http://foo.com/bar?query=%");
encodeURL("/bar?query=%");
```
```
URIError: URI malformed
      at decodeURI (<anonymous>)
      at encodeURL (lib/encode_url.js:25:20)
```

Use `try, catch` can prevent this exception.