### PR TITLE
fix(html_tag): encode url value of url-related attributes and skip escape/encode <style>

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Option | Description | Default
 --- | --- | ---
 `tag` | Tag / element name |
 `attrs` | Attribute(s) and its value.<br>Value is always [escaped](#escapehtmlstr), URL is always [encoded](#encodeurlstr). |
-`text` | Text |
+`text` | Text, the value is always escaped<br>_(except for `<style>` tag)_ |
 `escape` | Whether to escape the text | true
 
 ``` js
@@ -188,6 +188,10 @@ htmlTag('link', {href: 'http://foo.com/'}, '<a>bar</a>')
 
 htmlTag('a', {href: 'http://foo.com/'}, '<b>bold</b>', false)
 // <a href="http://foo.com/"><b>bold</b></a>
+
+/* text value of <style> won't be escaped */
+htmlTag('style', {}, 'p { content: "—"; background: url("bár.jpg"); }')
+// <style>p { content: "—"; background: url("bár.jpg"); }</style>
 ```
 
 ### Pattern(rule)

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -2,7 +2,6 @@
 
 const encodeURL = require('./encode_url');
 const escapeHTML = require('./escape_html');
-const { parse } = require('url');
 
 function htmlTag(tag, attrs, text, escape = true) {
   if (!tag) throw new TypeError('tag is required!');

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -22,8 +22,8 @@ function htmlTag(tag, attrs, text, escape = true) {
   for (const i in attrs) {
     if (attrs[i] === null || typeof attrs[i] === 'undefined') result += '';
     else {
-      if (i.endsWith('href') || i.endsWith('src') || i.endsWith('url')) result += ` ${i}="${encodeURL(attrs[i])}"`;
-      else if (i.endsWith('srcset')) result += ` ${i}="${encSrcset(attrs[i])}"`;
+      if (i.endsWith('href') || i.endsWith('src') || i.endsWith('url')) result += ` ${escapeHTML(i)}="${encodeURL(attrs[i])}"`;
+      else if (i.endsWith('srcset')) result += ` ${escapeHTML(i)}="${encSrcset(attrs[i])}"`;
       else result += ` ${escapeHTML(i)}="${escapeHTML(String(attrs[i]))}"`;
     }
   }

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -2,6 +2,7 @@
 
 const encodeURL = require('./encode_url');
 const escapeHTML = require('./escape_html');
+const { parse } = require('url');
 
 function htmlTag(tag, attrs, text, escape = true) {
   if (!tag) throw new TypeError('tag is required!');
@@ -11,7 +12,7 @@ function htmlTag(tag, attrs, text, escape = true) {
   for (const i in attrs) {
     if (attrs[i] === null || typeof attrs[i] === 'undefined') result += '';
     else {
-      if (i === 'href' || i === 'src') result += ` ${i}="${encodeURL(attrs[i])}"`;
+      if (i.includes('href') || i.includes('src') || i.includes('url')) result += ` ${i}="${encodeURL(attrs[i])}"`;
       else result += ` ${escapeHTML(i)}="${escapeHTML(String(attrs[i]))}"`;
     }
   }

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -2,6 +2,7 @@
 
 const encodeURL = require('./encode_url');
 const escapeHTML = require('./escape_html');
+const regexUrl = /(cite|download|href|src|url)$/;
 
 function encSrcset(str) {
   str.split(' ')
@@ -22,13 +23,13 @@ function htmlTag(tag, attrs, text, escape = true) {
   for (const i in attrs) {
     if (attrs[i] === null || typeof attrs[i] === 'undefined') result += '';
     else {
-      if (i.endsWith('href') || i.endsWith('src') || i.endsWith('url')) result += ` ${escapeHTML(i)}="${encodeURL(attrs[i])}"`;
+      if (i.match(regexUrl)) result += ` ${escapeHTML(i)}="${encodeURL(attrs[i])}"`;
       else if (i.endsWith('srcset')) result += ` ${escapeHTML(i)}="${encSrcset(attrs[i])}"`;
       else result += ` ${escapeHTML(i)}="${escapeHTML(String(attrs[i]))}"`;
     }
   }
 
-  if (escape && text) text = escapeHTML(String(text));
+  if (escape && text && tag !== 'style') text = escapeHTML(String(text));
 
   if (text === null || typeof text === 'undefined') result += '>';
   else result += `>${text}</${escapeHTML(tag)}>`;

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -11,7 +11,7 @@ function htmlTag(tag, attrs, text, escape = true) {
   for (const i in attrs) {
     if (attrs[i] === null || typeof attrs[i] === 'undefined') result += '';
     else {
-      if (i.includes('href') || i.includes('src') || i.includes('url')) result += ` ${i}="${encodeURL(attrs[i])}"`;
+      if (i.endsWith('href') || i.endsWith('src') || i.endsWith('url')) result += ` ${i}="${encodeURL(attrs[i])}"`;
       else result += ` ${escapeHTML(i)}="${escapeHTML(String(attrs[i]))}"`;
     }
   }

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -3,6 +3,17 @@
 const encodeURL = require('./encode_url');
 const escapeHTML = require('./escape_html');
 
+function encSrcset(str) {
+  str.split(' ')
+    .forEach(subStr => {
+      if (subStr.match(/\S/)) {
+        subStr = subStr.trim();
+        str = str.replace(subStr, encodeURI(subStr));
+      }
+    });
+  return str;
+}
+
 function htmlTag(tag, attrs, text, escape = true) {
   if (!tag) throw new TypeError('tag is required!');
 
@@ -12,6 +23,7 @@ function htmlTag(tag, attrs, text, escape = true) {
     if (attrs[i] === null || typeof attrs[i] === 'undefined') result += '';
     else {
       if (i.endsWith('href') || i.endsWith('src') || i.endsWith('url')) result += ` ${i}="${encodeURL(attrs[i])}"`;
+      else if (i.endsWith('srcset')) result += ` ${i}="${encSrcset(attrs[i])}"`;
       else result += ` ${escapeHTML(i)}="${escapeHTML(String(attrs[i]))}"`;
     }
   }

--- a/test/html_tag.spec.js
+++ b/test/html_tag.spec.js
@@ -81,4 +81,19 @@ describe('htmlTag', () => {
     }, '<baz>', false).should.eql('<foo bar="&lt;b&gt;"><baz></foo>');
   });
 
+  it('srcset', () => {
+    htmlTag('img', {
+      srcset: 'fóo.jpg 320w,/foo/bár.jpeg 480w,default.png'
+    }).should.eql('<img srcset="f%C3%B3o.jpg 320w,/foo/b%C3%A1r.jpeg 480w,default.png">');
+  });
+
+  it('srcset with whitespace', () => {
+    htmlTag('img', {
+      srcset: `fóo.jpg 320w,
+        /foo/bár.jpeg 480w,
+        default.png`
+    }).should.eql(`<img srcset="f%C3%B3o.jpg 320w,
+        /foo/b%C3%A1r.jpeg 480w,
+        default.png">`);
+  });
 });

--- a/test/html_tag.spec.js
+++ b/test/html_tag.spec.js
@@ -96,4 +96,9 @@ describe('htmlTag', () => {
         /foo/b%C3%A1r.jpeg 480w,
         default.png">`);
   });
+
+  it('should not escape/encode style tag', () => {
+    const text = 'p { content: "—"; background: url("bár.jpg"); }';
+    htmlTag('style', {}, text).should.eql('<style>' + text + '</style>');
+  });
 });


### PR DESCRIPTION
address https://github.com/hexojs/hexo-util/pull/94#issuecomment-531865496 to support url value in data-* attributes (e.g. data-url, [`data-src`](https://cloudinary.com/documentation/responsive_images#step_2_set_the_img_tag_parameters))
cc @dailyrandomphoto

test case is already covered by
``` js
  it('encode url', () => {
    htmlTag('img', {
      src: 'http://foo.com/bár.jpg'
    }).should.eql('<img src="http://foo.com/b%C3%A1r.jpg">');
  });
```