### PR TITLE
release: 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-util",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Utilities for Hexo.",
   "main": "lib/index",
   "scripts": {


### PR DESCRIPTION
to include #92 #93 #97 #96
note #93 is a possible breaking change, for an edge case like `<a href="foo.com"><b>text</b></a>`.