### PR TITLE
docs: override example should be consistent with example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,8 @@ url_for('/css/style.css')
 // ../../css/style.css
 
 /* Override option
- * you could also enable it to output a relative link,
- * even when `relative_link` is disabled and vice versa.
+ * you could also disable it to output a non-relative link,
+ * even when `relative_link` is enabled and vice versa.
  */
 url_for('/css/style.css', {relative: false})
 // /css/style.css


### PR DESCRIPTION
Noticed while working on https://github.com/hexojs/site/issues/1085