### PR TITLE
fix(html_tag): encode url() in style tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,9 @@ htmlTag('link', {href: 'http://foo.com/'}, '<a>bar</a>')
 htmlTag('a', {href: 'http://foo.com/'}, '<b>bold</b>', false)
 // <a href="http://foo.com/"><b>bold</b></a>
 
-/* text value of <style> won't be escaped */
-htmlTag('style', {}, 'p { content: "—"; background: url("bár.jpg"); }')
-// <style>p { content: "—"; background: url("bár.jpg"); }</style>
+/* text value of <style> won't be escaped, url is still encoded */
+htmlTag('style', {}, 'p { content: "<"; background: url("bár.jpg"); }')
+// <style>p { content: "<"; background: url("b%C3%A1r.jpg"); }</style>
 ```
 
 ### Pattern(rule)

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -30,6 +30,11 @@ function htmlTag(tag, attrs, text, escape = true) {
   }
 
   if (escape && text && tag !== 'style') text = escapeHTML(String(text));
+  if (text && tag === 'style') {
+    text = text.replace(/url\(['"](.*?)['"]\)/gi, (urlAttr, url) => {
+      return `url("${encodeURL(url)}")`;
+    });
+  }
 
   if (text === null || typeof text === 'undefined') result += '>';
   else result += `>${text}</${escapeHTML(tag)}>`;

--- a/test/html_tag.spec.js
+++ b/test/html_tag.spec.js
@@ -97,8 +97,13 @@ describe('htmlTag', () => {
         default.png">`);
   });
 
-  it('should not escape/encode style tag', () => {
-    const text = 'p { content: "—"; background: url("bár.jpg"); }';
+  it('should not encode style tag', () => {
+    const text = 'p { content: "<"; }';
     htmlTag('style', {}, text).should.eql('<style>' + text + '</style>');
+  });
+
+  it('should encode url in style tag', () => {
+    const text = 'p { background: url("bár.jpg"); }';
+    htmlTag('style', {}, text).should.eql('<style>p { background: url("b%C3%A1r.jpg"); }</style>');
   });
 });


### PR DESCRIPTION
Continuation of https://github.com/hexojs/hexo-util/pull/96#discussion_r326639896

Regex is based on [`external_link.js`](https://github.com/hexojs/hexo/blob/master/lib/plugins/filter/after_post_render/external_link.js)