### PR TITLE
fix(encode_url): skip encode non-urls

### DIFF
--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { parse, format } = require('url');
-const regexNonUrl = /^(data|javascript|mailto|vbscript)/gi
+const regexNonUrl = /^(data|javascript|mailto|vbscript)/gi;
 
 function encodeURL(str) {
   const parsed = parse(str);

--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const { parse, format } = require('url');
+const regexNonUrl = /^(data|javascript|mailto|vbscript)/gi
 
 function encodeURL(str) {
   const parsed = parse(str);
-  if (parsed.protocol) {
+  if (parsed.slashes) {
     const obj = Object.assign({}, {
       auth: parsed.auth,
       protocol: parsed.protocol,
@@ -22,6 +23,8 @@ function encodeURL(str) {
 
     return format(obj);
   }
+
+  if (str.match(regexNonUrl)) return str;
 
   return encodeURI(safeDecodeURI(str));
 }

--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { parse, format } = require('url');
-const regexNonUrl = /^(data|javascript|mailto|vbscript)/gi;
+const regexNonUrl = /^(data|javascript|mailto|vbscript)/i;
 
 function encodeURL(str) {
   const parsed = parse(str);

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -2,7 +2,7 @@
 
 const encodeURL = require('./encode_url');
 const escapeHTML = require('./escape_html');
-const regexUrl = /(cite|download|href|src|url)$/;
+const regexUrl = /(cite|download|href|src|url)$/i;
 
 function encSrcset(str) {
   str.split(' ')
@@ -24,7 +24,7 @@ function htmlTag(tag, attrs, text, escape = true) {
     if (attrs[i] === null || typeof attrs[i] === 'undefined') result += '';
     else {
       if (i.match(regexUrl)) result += ` ${escapeHTML(i)}="${encodeURL(attrs[i])}"`;
-      else if (i.endsWith('srcset')) result += ` ${escapeHTML(i)}="${encSrcset(attrs[i])}"`;
+      else if (i.match(/srcset$/i)) result += ` ${escapeHTML(i)}="${encSrcset(attrs[i])}"`;
       else result += ` ${escapeHTML(i)}="${escapeHTML(String(attrs[i]))}"`;
     }
   }

--- a/test/encode_url.spec.js
+++ b/test/encode_url.spec.js
@@ -94,4 +94,9 @@ describe('encodeURL', () => {
     const content = '#fóo-bár';
     encodeURL(content).should.eql('#f%C3%B3o-b%C3%A1r');
   });
+
+  it('data URLs', () => {
+    const content = 'data:,Hello%2C%20World!';
+    encodeURL(content).should.eql(content);
+  });
 });


### PR DESCRIPTION
`url.parse(str).slashes` is used to avoid treating `mailto:` as a transfer protocol (e.g. http, ftp).
``` js
const { parse } = require('url')
console.log(parse('mailto:abc@example.com'))
/*
Url {
  protocol: 'mailto:',
  slashes: null,
  auth: 'abc',
  host: 'example.com',
  port: null,
  hostname: 'example.com',
  hash: null,
  search: null,
  query: null,
  pathname: null,
  path: null,
  href: 'mail:abc@example.com'
}
*/
```

This avoids `null` from being appended undesirably.

---

- Expected behavior
``` js
encodeURL('mailto:abc@example.com')
// mailto:abc@example.com
```

- Actual behavior 
``` js
encodeURL('mailto:abc@example.com')
// mailto:abc@example.comnull
```

Address https://github.com/hexojs/hexo/pull/3710#issuecomment-533863007