### PR TITLE
feat: add unescapeHTML() & fix(escapeHTML): avoid double escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ Escapes diacritic characters in a string.
 
 Escapes HTML entities in a string.
 
+``` js
+escapeHTML('<p>Hello "world".</p>')
+// &lt;p&gt;Hello &quot;world&quot;.&lt;&#x2F;p&gt;
+
+/* support escaped characters */
+escapeHTML('&lt;foo>bar</foo&gt;')
+// &lt;foo&gt;bar&lt;&#x2F;foo&gt;
+```
+
 ### escapeRegex(str)
 
 Escapes special characters in a regular expression.
@@ -349,6 +358,15 @@ truncate('Once upon a time in a world far far away', {length: 17, separator: ' '
 
 truncate('And they found that many people were sleeping better.', {length: 25, omission: '... (continued)'})
 // "And they f... (continued)"
+```
+
+### unescapeHTML(str)
+
+Unescapes HTML entities in a string.
+
+``` js
+unescapeHTML('&lt;p&gt;Hello &quot;world&quot;.&lt;&#x2F;p&gt;')
+// <p>Hello "world".</p>
 ```
 
 ### url_for(path, [option])

--- a/lib/escape_html.js
+++ b/lib/escape_html.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const unescapeHTML = require('./unescape_html');
+
 const htmlEntityMap = {
   '&': '&amp;',
   '<': '&lt;',
@@ -11,6 +13,8 @@ const htmlEntityMap = {
 
 function escapeHTML(str) {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
+
+  str = unescapeHTML(str);
 
   // http://stackoverflow.com/a/12034334
   return str.replace(/[&<>"'/]/g, a => htmlEntityMap[a]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,5 +24,6 @@ exports.slugize = require('./slugize');
 exports.spawn = require('./spawn');
 exports.stripHTML = require('./strip_html');
 exports.truncate = require('./truncate');
+exports.unescapeHTML = require('./unescape_html');
 exports.url_for = require('./url_for');
 exports.wordWrap = require('./word_wrap');

--- a/lib/unescape_html.js
+++ b/lib/unescape_html.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const htmlEntityMap = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': '\'',
+  '&#x2F;': '/'
+};
+
+const regexHtml = new RegExp(Object.keys(htmlEntityMap).join('|'), 'g');
+
+const unescapeHTML = (str) => {
+  if (typeof str !== 'string') throw new TypeError('str must be a string!');
+
+  return str.replace(regexHtml, a => htmlEntityMap[a]);
+};
+
+module.exports = unescapeHTML;

--- a/test/escape_html.spec.js
+++ b/test/escape_html.spec.js
@@ -12,4 +12,8 @@ describe('escapeHTML', () => {
   it('str must be a string', () => {
     escapeHTML.should.throw('str must be a string!');
   });
+
+  it('avoid double escape', () => {
+    escapeHTML('&lt;foo>bar</foo&gt;').should.eql('&lt;foo&gt;bar&lt;&#x2F;foo&gt;');
+  });
 });

--- a/test/unescape_html.spec.js
+++ b/test/unescape_html.spec.js
@@ -1,0 +1,15 @@
+'use strict';
+
+require('chai').should();
+
+describe('unescapeHTML', () => {
+  const unescapeHTML = require('../lib/unescape_html');
+
+  it('default', () => {
+    unescapeHTML('&lt;p&gt;Hello &quot;world&quot;.&lt;&#x2F;p&gt;').should.eql('<p>Hello "world".</p>');
+  });
+
+  it('str must be a string', () => {
+    unescapeHTML.should.throw('str must be a string!');
+  });
+});


### PR DESCRIPTION
Noticed an edge case where ampersand `&` is escaped twice, while working on https://github.com/hexojs/hexo/pull/3686 which I had to use [this workaround]( https://github.com/hexojs/hexo/pull/3686/files#diff-c4a1a49a7c6ed5695f830ccde3a217c3).