### PR TITLE
fix(highlight): code in blockquote

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -61,6 +61,7 @@ function highlightUtil(str, options = {}) {
 function formatLine(line, lineno, marked, options) {
   const useHljs = options.hljs || false;
   let res = useHljs ? '' : '<span class="line';
+
   if (marked.includes(lineno)) {
     // Handle marked lines.
     res += useHljs ? `<mark>${line}</mark>` : ` marked">${line}</span>`;
@@ -132,7 +133,16 @@ function tryHighlight(str, lang) {
       html += separator + result.value;
     }
 
+    // https://github.com/hexojs/hexo/issues/2969
+    if (lang !== 'cmd' && lang !== 'dos') {
+      html = html.replace(/&gt;.*/g, (str) => {
+        str = str.replace(/^&gt;(\s)?(?!<\/span>)/, '');
+        return str;
+      }).trimRight();
+    }
+
     result.value = html;
+
     return result;
   } catch (err) {
 

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -295,4 +295,18 @@ describe('highlight', () => {
     result.should.include('class="hljs-function"');
     validateHtmlAsync(result, done);
   });
+
+  it('codeblock inside a blockquote', (done) => {
+    const str = '> let foo = false';
+    const result = highlight(str, {gutter: false, lang: 'javascript' });
+    result.should.not.include('&gt;');
+    validateHtmlAsync(result, done);
+  });
+
+  it('codeblock inside a blockquote - exclude cmd lang', (done) => {
+    const str = '> ipconfig';
+    const result = highlight(str, {gutter: false, lang: 'cmd' });
+    result.should.include('&gt;');
+    validateHtmlAsync(result, done);
+  });
 });


### PR DESCRIPTION
Currently, when inserting a codeblock inside a blockquote, e.g.

```
> ```json
> {
>   "test": 123
> }
> ```
```

results in,

> ``` json
>> {
>>  "test": 123
>> }
>```

---

Expected behavior is

>``` json
> {
>  "test": 123
> }
>```

This fixes https://github.com/hexojs/hexo/issues/2969 & https://github.com/hexojs/hexo/issues/3318.

However, this fix doesn't apply to `cmd` or `dos` codeblock because the line may start with `>`, e.g.

``` cmd
> ipconfig
```

cmd codeblock in blockquote,
```
> ```cmd
>> ipconfig
> ```
```

would result in,

> ```cmd
>> ipconfig
>>

A workaround is to remove `>` from the closing backtick,

https://pastebin.com/s94kaD4j

which should render as,

> ```cmd
> > ipconfig
> ```

or use [`{% blockquote %}`](https://hexo.io/docs/tag-plugins#Block-Quote) tag plugin.