### PR TITLE
Make consistency in output of "highlight()" for "wrap: false" (fix #111)

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -21,13 +21,16 @@ function highlightUtil(str, options = {}) {
   hljs.configure({ classPrefix: useHljs ? 'hljs-' : ''});
 
   const data = highlight(str, options);
+  const lang = options.lang || data.language || '';
+  const classNames = (useHljs ? 'hljs' : 'highlight') + (lang ? ` ${lang}` : '');
 
   if (useHljs && !gutter) wrap = false;
+  if (gutter && !wrap) wrap = true; // arbitrate conflict ("gutter:true" takes priority over "wrap:false")
 
-  const before = useHljs ? `<pre><code class="hljs ${options.lang}">` : '<pre>';
+  const before = useHljs ? `<pre><code class="${classNames}">` : '<pre>';
   const after = useHljs ? '</code></pre>' : '</pre>';
 
-  if (!wrap) return useHljs ? before + data.value + after : data.value;
+  if (!wrap) return `<pre><code class="${classNames}">${data.value}</code></pre>`;
 
   const lines = data.value.split('\n');
   let numbers = '';

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -85,9 +85,51 @@ describe('highlight', () => {
     validateHtmlAsync(result, done);
   });
 
-  it('wrap: false', done => {
-    const result = highlight(testString, {wrap: false});
-    result.should.eql(entities.encode(testString));
+  it('gutter: true, but "wrap: false" (conflict)', done => {
+    const result = highlight(testString, {gutter: true, wrap: false});
+    assertResult(result, gutter(1, 4), code(testString));
+    validateHtmlAsync(result, done);
+  });
+
+  it('wrap: false (without hljs, without lang)', done => {
+    const result = highlight(testString, {gutter: false, wrap: false});
+    result.should.eql([
+      '<pre><code class="highlight plain">',
+      entities.encode(testString),
+      '</code></pre>'
+    ].join(''));
+    validateHtmlAsync(result, done);
+  });
+
+  it('wrap: false (with hljs, without lang)', done => {
+    const result = highlight(testString, {gutter: false, wrap: false, hljs: true});
+    result.should.eql([
+      '<pre><code class="hljs plain">',
+      entities.encode(testString),
+      '</code></pre>'
+    ].join(''));
+    validateHtmlAsync(result, done);
+  });
+
+  it('wrap: false (without hljs, with lang)', done => {
+    const result = highlight(testString, {gutter: false, wrap: false, lang: 'json'});
+    hljs.configure({classPrefix: ''});
+    result.should.eql([
+      '<pre><code class="highlight json">',
+      hljs.highlight('json', testString).value,
+      '</code></pre>'
+    ].join(''));
+    validateHtmlAsync(result, done);
+  });
+
+  it('wrap: false (with hljs, with lang)', done => {
+    const result = highlight(testString, {gutter: false, wrap: false, hljs: true, lang: 'json'});
+    hljs.configure({classPrefix: 'hljs-'});
+    result.should.eql([
+      '<pre><code class="hljs json">',
+      hljs.highlight('json', testString).value,
+      '</code></pre>'
+    ].join(''));
     validateHtmlAsync(result, done);
   });
 


### PR DESCRIPTION
Fix #111

This patch is fix the behavior of `highlight()` with a option `wrap: false`.

If `hljs: false`, the output of `highlight()` should include a HTML class name `highlight`.
It is consistent with the case of `hljs: true`.

And also, even if `hljs: false`, the output of `highlight()` should be include a PRE element and a CODE element.
It is consistent with the case of `hljs: true`, too.
