### PR TITLE
refactor: whatwg url api

### DIFF
--- a/lib/decode_url.js
+++ b/lib/decode_url.js
@@ -1,5 +1,9 @@
 'use strict';
 
+// To be refactored to WHATWG URL API
+// after support for Node 8 is dropped.
+// url.format(WHATWG URL object) in Node 8 doesn't support port number
+
 const { parse, format } = require('url');
 const { toUnicode } = require('./punycode');
 

--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -1,40 +1,33 @@
 'use strict';
 
-const { parse, format } = require('url');
-const regexNonUrl = /^(data|javascript|mailto|vbscript)/i;
+const { URL } = require('url');
 
-function encodeURL(str) {
-  const parsed = parse(str);
-  if (parsed.slashes) {
-    const obj = Object.assign({}, {
-      auth: parsed.auth,
-      protocol: parsed.protocol,
-      host: parsed.host,
-      pathname: encodeURI(safeDecodeURI(parsed.pathname))
-    });
-
-    if (parsed.hash) {
-      Object.assign(obj, { hash: encodeURI(safeDecodeURI(parsed.hash)) });
-    }
-
-    if (parsed.search) {
-      Object.assign(obj, { search: encodeURI(safeDecodeURI(parsed.search)) });
-    }
-
-    return format(obj);
+const urlObj = (str) => {
+  try {
+    return new URL(str);
+  } catch (err) {
+    return str;
   }
+};
 
-  if (str.match(regexNonUrl)) return str;
-
-  return encodeURI(safeDecodeURI(str));
-}
-
-function safeDecodeURI(str) {
+const safeDecodeURI = (str) => {
   try {
     return decodeURI(str);
   } catch (err) {
     return str;
   }
-}
+};
+
+const encodeURL = (str) => {
+  const parsed = urlObj(str);
+  if (typeof parsed === 'object') {
+    if (parsed.origin === 'null') return str;
+
+    parsed.search = encodeURI(safeDecodeURI(parsed.search));
+    return parsed.toString();
+  }
+
+  return encodeURI(safeDecodeURI(str));
+};
 
 module.exports = encodeURL;

--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -17,7 +17,9 @@ function fullUrlForHelper(path = '/') {
   const data = urlObj(path);
 
   // Exit if this is an external path
-  if (typeof data === 'object') return path;
+  if (typeof data === 'object') {
+    if (data.origin !== 'null') return path;
+  }
 
   path = encodeURL(config.url + `/${path}`.replace(/\/{2,}/g, '/'));
   return path;

--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -1,15 +1,23 @@
 'use strict';
 
-const { parse } = require('url');
+const { URL } = require('url');
 const encodeURL = require('./encode_url');
+
+const urlObj = (str) => {
+  try {
+    return new URL(str);
+  } catch (err) {
+    return str;
+  }
+};
 
 function fullUrlForHelper(path = '/') {
   if (path.startsWith('//')) return path;
   const { config } = this;
-  const data = parse(path);
+  const data = urlObj(path);
 
   // Exit if this is an external path
-  if (data.protocol) return path;
+  if (typeof data === 'object') return path;
 
   path = encodeURL(config.url + `/${path}`.replace(/\/{2,}/g, '/'));
   return path;

--- a/lib/url_for.js
+++ b/lib/url_for.js
@@ -1,8 +1,16 @@
 'use strict';
 
-const { parse } = require('url');
+const { URL } = require('url');
 const encodeURL = require('./encode_url');
 const relative_url = require('./relative_url');
+
+const urlObj = (str) => {
+  try {
+    return new URL(str);
+  } catch (err) {
+    return str;
+  }
+};
 
 function urlForHelper(path = '/', options) {
   if (path[0] === '#' || path.startsWith('//')) {
@@ -11,14 +19,14 @@ function urlForHelper(path = '/', options) {
 
   const { config } = this;
   const { root } = config;
-  const data = parse(path);
+  const data = urlObj(path);
 
   options = Object.assign({
     relative: config.relative_link
   }, options);
 
   // Exit if this is an external path
-  if (data.protocol) {
+  if (typeof data === 'object') {
     return path;
   }
 

--- a/lib/url_for.js
+++ b/lib/url_for.js
@@ -27,7 +27,7 @@ function urlForHelper(path = '/', options) {
 
   // Exit if this is an external path
   if (typeof data === 'object') {
-    return path;
+    if (data.origin !== 'null') return path;
   }
 
   // Resolve relative url

--- a/test/decode_url.spec.js
+++ b/test/decode_url.spec.js
@@ -16,7 +16,7 @@ describe('decodeURL', () => {
   });
 
   it('port', () => {
-    const content = 'http://foo.com:80/';
+    const content = 'http://foo.com:8080/';
     decodeURL(content).should.eql(content);
   });
 

--- a/test/encode_url.spec.js
+++ b/test/encode_url.spec.js
@@ -16,7 +16,7 @@ describe('encodeURL', () => {
   });
 
   it('port', () => {
-    const content = 'http://foo.com:80/';
+    const content = 'http://foo.com:8080/';
     encodeURL(content).should.eql(content);
   });
 

--- a/test/full_url_for.spec.js
+++ b/test/full_url_for.spec.js
@@ -37,4 +37,9 @@ describe('full_url_for', () => {
     ctx.config.url = 'https://example.com/blog';
     fullUrlFor('#test').should.eql(ctx.config.url + '/#test');
   });
+
+  it('path with semicolon', () => {
+    ctx.config.url = 'https://example.com/blog';
+    fullUrlFor('foo:bar').should.eql(ctx.config.url + '/foo:bar');
+  });
 });

--- a/test/url_for.spec.js
+++ b/test/url_for.spec.js
@@ -72,4 +72,12 @@ describe('url_for', () => {
   it('only hash', () => {
     urlFor('#test').should.eql('#test');
   });
+
+  it('path with semicolon', () => {
+    ctx.config.root = '/';
+    urlFor('foo:bar').should.eql('/foo:bar');
+
+    ctx.config.root = '/foo/';
+    urlFor('bar:baz').should.eql('/foo/bar:baz');
+  });
 });


### PR DESCRIPTION
legacy URL api has been deprecated in Node v11; while the API is still available in Node 12, `eslint-plugin-node` considers it as a deprecated api, thus will emit error if detected.

WHATWG url is actually introduced back in Node v7, thus contrary to my previous PR (https://github.com/hexojs/eslint-config-hexo/pull/19), it is supported in Node 8. The only thing is that Node 8 requires `const {URL} = require('url')`, whereas newer Node doesn't.

Another noticeable difference is that WHATWG remove the port number if it corresponds to the protocol (e.g. `http`:`80`, `https`:`443`), which explains the change of port number in the unit test.

`decode_url` is not refactored to the newer API for now due to a bug in Node 8,

``` js
const {format} = require('url')
const bob = new URL('http://user:pass@foo.com:8080/')
console.log(format(bob, { unicode: true }))
// http://user:pass@/
// Domain is removed if port number exists
```

Once we drop Node 8, not only we can update `decode_url`, we can also remove `const {URL} = require('url')` line. It's ok to retain it, but it's not necessary.