### PR TITLE
docs(decodeURL): add native API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ decodeURL('http://xn--br-mia.com/baz')
 
 decodeURL('/foo/b%C3%A1r/')
 // /foo/bár/
+
+/* Alternatively, Node 10+ offers native API to decode punycoded domain */
+const {format} = require('url')
+decodeURI(format(new URL('http://xn--br-mia.com.com/b%C3%A1r'), {unicode: true}))
+// http://bár.com/báz
 ```
 
 ### encodeURL(str)


### PR DESCRIPTION
This is what I would've implemented in https://github.com/hexojs/hexo-util/pull/114, if not for the bug in Node 8.