### PR TITLE
Leave IDN intact in permalink

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,14 +113,11 @@ decodeURI(format(new URL('http://xn--br-mia.com.com/b%C3%A1r'), {unicode: true})
 
 ### encodeURL(str)
 
-Encode URL or path into a [safe format](https://en.wikipedia.org/wiki/Percent-encoding). Domain is encoded into [punycode](https://en.wikipedia.org/wiki/Punycode) when necessary.
+Encode URL or path into a [safe format](https://en.wikipedia.org/wiki/Percent-encoding).
 
 ``` js
 encodeURL('http://foo.com/bár')
 // http://foo.com/b%C3%A1r
-
-encodeURL('http://bár.com/baz')
-// http://xn--br-mia.com/baz
 
 encodeURL('/foo/bár/')
 // /foo/b%C3%A1r/

--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { URL } = require('url');
+const { URL, format } = require('url');
 
 const urlObj = (str) => {
   try {
@@ -24,7 +24,8 @@ const encodeURL = (str) => {
     if (parsed.origin === 'null') return str;
 
     parsed.search = encodeURI(safeDecodeURI(parsed.search));
-    return parsed.toString();
+    // preserve host (international domain name) as is.
+    return format(parsed, { unicode: true});
   }
 
   return encodeURI(safeDecodeURI(str));

--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const { URL, format } = require('url');
+const { toUnicode } = require('./punycode');
+const { URL } = require('url');
 
 const urlObj = (str) => {
   try {
@@ -24,8 +25,9 @@ const encodeURL = (str) => {
     if (parsed.origin === 'null') return str;
 
     parsed.search = encodeURI(safeDecodeURI(parsed.search));
-    // preserve host (international domain name) as is.
-    return format(parsed, { unicode: true});
+    // preserve IDN
+    // TODO: refactor to url.format() once Node 8 EOL
+    return parsed.toString().replace(parsed.hostname, toUnicode(parsed.hostname));
   }
 
   return encodeURI(safeDecodeURI(str));

--- a/test/encode_url.spec.js
+++ b/test/encode_url.spec.js
@@ -70,6 +70,11 @@ describe('encodeURL', () => {
     encodeURL(content).should.eql('http://bár.com/baz');
   });
 
+  it('idn - punycode', () => {
+    const content = 'http://xn--br-mia.com/baz';
+    encodeURL(content).should.eql('http://bár.com/baz');
+  });
+
   it('path', () => {
     const content = '/foo/bar/';
     encodeURL(content).should.eql(content);

--- a/test/encode_url.spec.js
+++ b/test/encode_url.spec.js
@@ -67,7 +67,7 @@ describe('encodeURL', () => {
 
   it('idn', () => {
     const content = 'http://bár.com/baz';
-    encodeURL(content).should.eql('http://xn--br-mia.com/baz');
+    encodeURL(content).should.eql('http://bár.com/baz');
   });
 
   it('path', () => {


### PR DESCRIPTION
Because IDN only contain unicode, they do not need to be punycode encoded.
(I bought one, I want the nice version, not the ugly one)
See https://nodejs.org/docs/latest/api/url.html#url_url_format_url_options