### PR TITLE
refactor(decodeURL): update to whatwg api

### DIFF
--- a/lib/decode_url.js
+++ b/lib/decode_url.js
@@ -1,11 +1,15 @@
 'use strict';
 
-// To be refactored to WHATWG URL API
-// after support for Node 8 is dropped.
-// url.format(WHATWG URL object) in Node 8 doesn't support port number
-
-const { parse, format } = require('url');
+const { URL } = require('url');
 const { toUnicode } = require('./punycode');
+
+const urlObj = (str) => {
+  try {
+    return new URL(str);
+  } catch (err) {
+    return str;
+  }
+};
 
 const safeDecodeURI = (str) => {
   try {
@@ -16,24 +20,13 @@ const safeDecodeURI = (str) => {
 };
 
 const decodeURL = (str) => {
-  const parsed = parse(str);
-  if (parsed.protocol) {
-    const obj = Object.assign({}, {
-      auth: parsed.auth,
-      protocol: parsed.protocol,
-      host: toUnicode(parsed.host),
-      pathname: safeDecodeURI(parsed.pathname)
-    });
+  const parsed = urlObj(str);
+  if (typeof parsed === 'object') {
+    if (parsed.origin === 'null') return str;
 
-    if (parsed.hash) {
-      Object.assign(obj, { hash: safeDecodeURI(parsed.hash) });
-    }
-
-    if (parsed.search) {
-      Object.assign(obj, { search: safeDecodeURI(parsed.search) });
-    }
-
-    return format(obj);
+    // TODO: refactor to `url.format()` once Node 8 is dropped
+    const url = parsed.toString().replace(parsed.hostname, toUnicode(parsed.hostname));
+    return safeDecodeURI(url);
   }
 
   return safeDecodeURI(str);


### PR DESCRIPTION
Continuation of #114 

Node 8's `url.format()` doesn't support port number, so a workaround is used instead.