### PR TITLE
fix(isExternal): url parameter can be an internal link

### DIFF
--- a/lib/is_external_link.js
+++ b/lib/is_external_link.js
@@ -21,7 +21,7 @@ function isExternalLink(url) {
   const exclude = Array.isArray(config.external_link.exclude) ? config.external_link.exclude
     : [config.external_link.exclude];
   const data = urlObj(url);
-  const host = data.hostname;
+  const host = typeof data === 'object' ? data.hostname : '';
   const sitehost = typeof urlObj(config.url) === 'object' ? urlObj(config.url).hostname : config.url;
 
   if (!sitehost || typeof data === 'string') return false;


### PR DESCRIPTION
I just noticed a silent issue.

``` js
const data = urlObj(url);
const host = data.hostname;
```

`data` will be a string when `url` is an internal link, resulting in `host` being assigned as `undefined`. when it is "undefined", it won't be used, thanks to

``` js
if (!sitehost || typeof data === 'string') return false;
```

While current code won't cause any crash, it's a bit unsafe to leave it "undefined" and also could lead to incorrect assumption that `data` is always a URL object.