### PR TITLE
perf(encode/decodeURL): use legacy url.parse() to avoid try...catch()

### DIFF
--- a/lib/decode_url.js
+++ b/lib/decode_url.js
@@ -1,15 +1,7 @@
 'use strict';
 
-const { URL } = require('url');
+const { parse, URL } = require('url');
 const { toUnicode } = require('./punycode');
-
-const urlObj = (str) => {
-  try {
-    return new URL(str);
-  } catch (err) {
-    return str;
-  }
-};
 
 const safeDecodeURI = (str) => {
   try {
@@ -20,8 +12,9 @@ const safeDecodeURI = (str) => {
 };
 
 const decodeURL = (str) => {
-  const parsed = urlObj(str);
-  if (typeof parsed === 'object') {
+  if (parse(str).protocol) {
+    const parsed = new URL(str);
+
     if (parsed.origin === 'null') return str;
 
     // TODO: refactor to `url.format()` once Node 8 is dropped

--- a/lib/decode_url.js
+++ b/lib/decode_url.js
@@ -15,6 +15,7 @@ const decodeURL = (str) => {
   if (parse(str).protocol) {
     const parsed = new URL(str);
 
+    // Exit if input is a data url
     if (parsed.origin === 'null') return str;
 
     // TODO: refactor to `url.format()` once Node 8 is dropped

--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -14,6 +14,7 @@ const safeDecodeURI = (str) => {
 const encodeURL = (str) => {
   if (parse(str).protocol) {
     const parsed = new URL(str);
+
     if (parsed.origin === 'null') return str;
 
     parsed.search = encodeURI(safeDecodeURI(parsed.search));

--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -1,15 +1,7 @@
 'use strict';
 
 const { toUnicode } = require('./punycode');
-const { URL } = require('url');
-
-const urlObj = (str) => {
-  try {
-    return new URL(str);
-  } catch (err) {
-    return str;
-  }
-};
+const { parse, URL } = require('url');
 
 const safeDecodeURI = (str) => {
   try {
@@ -20,8 +12,8 @@ const safeDecodeURI = (str) => {
 };
 
 const encodeURL = (str) => {
-  const parsed = urlObj(str);
-  if (typeof parsed === 'object') {
+  if (parse(str).protocol) {
+    const parsed = new URL(str);
     if (parsed.origin === 'null') return str;
 
     parsed.search = encodeURI(safeDecodeURI(parsed.search));

--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -15,6 +15,7 @@ const encodeURL = (str) => {
   if (parse(str).protocol) {
     const parsed = new URL(str);
 
+    // Exit if input is a data url
     if (parsed.origin === 'null') return str;
 
     parsed.search = encodeURI(safeDecodeURI(parsed.search));


### PR DESCRIPTION
Part of https://github.com/hexojs/hexo/issues/3846

TL;DR

``` js
  try {
    return new URL(str);
  } catch (err) {
    return str;
  }
```

is expensive.