### PR TITLE
refactor: relpace node-html-entities with escapeHTML()

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const hljs = require('highlight.js');
-const Entities = require('html-entities').XmlEntities;
-const entities = new Entities();
 const alias = require('../highlight_alias.json');
+
+const escapeHTML = require('./escape_html');
 
 function highlightUtil(str, options = {}) {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
@@ -76,7 +76,7 @@ function formatLine(line, lineno, marked, options) {
 }
 
 function encodePlainString(str) {
-  return entities.encode(str);
+  return escapeHTML(str);
 }
 
 function replaceTabs(str, tab) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^6.0.1",
     "eslint-config-hexo": "^3.0.0",
+    "html-entities": "^1.2.1",
     "html-tag-validator": "^1.5.0",
     "mocha": "^6.0.1",
     "nyc": "^14.1.1",
@@ -46,7 +47,6 @@
     "camel-case": "^3.0.0",
     "cross-spawn": "^7.0.0",
     "highlight.js": "^9.13.1",
-    "html-entities": "^1.2.1",
     "striptags": "^3.1.1"
   },
   "engines": {


### PR DESCRIPTION
Fix #127. Use hexo-util's built-in `escapeHTML()` to replace `node-html-entities`, while retains `node-html-entities` in unit-test to make sure the behaviors of highlight remain unchanged after this PR.