### PR TITLE
feat(highlight): adjust the layout of the highlight code block

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -32,31 +32,29 @@ function highlightUtil(str, options = {}) {
 
   if (!wrap) return `<pre><code class="${classNames}">${data.value}</code></pre>`;
 
-  const lines = data.value.split('\n');
-  let numbers = '';
-  let content = '';
-
-  for (let i = 0, len = lines.length; i < len; i++) {
-    let line = lines[i];
-    if (tab) line = replaceTabs(line, tab);
-    numbers += `<span class="line">${Number(firstLine) + i}</span><br>`;
-    content += formatLine(line, Number(firstLine) + i, mark, options);
-  }
-
   let result = `<figure class="highlight${data.language ? ` ${data.language}` : ''}">`;
 
   if (caption) {
     result += `<figcaption>${caption}</figcaption>`;
   }
 
-  result += '<table><tr>';
+  result += '<table>';
 
-  if (gutter) {
-    result += `<td class="gutter"><pre>${numbers}</pre></td>`;
+  const lines = data.value.split('\n');
+
+  for (let i = 0, len = lines.length; i < len; i++) {
+    let line = lines[i];
+    if (tab) line = replaceTabs(line, tab);
+    let content = formatLine(line, Number(firstLine) + i, mark, options);
+
+    result += '<tr>';
+    if (gutter) {
+      result += `<td class="gutter"><pre><span class="line">${Number(firstLine) + i}</span></pre></td>`;
+    }
+    result += `<td class="code">${before}${content}${after}</td></tr>`;
   }
 
-  result += `<td class="code">${before}${content}${after}</td>`;
-  result += '</tr></table></figure>';
+  result += '</table></figure>';
 
   return result;
 }
@@ -71,7 +69,6 @@ function formatLine(line, lineno, marked, options) {
     res += useHljs ? line : `">${line}</span>`;
   }
 
-  res += '<br>';
   return res;
 }
 

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -217,7 +217,7 @@ describe('highlight', () => {
       '`'
     ].join('\n');
 
-    const result = highlight(str, { lang: 'js' });
+    const result = highlight(str, {lang: 'js'});
     assertResult(result, gutter(1, 5), code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string">  line</span>\n<span class="string">  string</span>\n<span class="string">`</span>', null), 'js');
     validateHtmlAsync(result, done);
   });
@@ -231,7 +231,7 @@ describe('highlight', () => {
       '`'
     ].join('\n');
 
-    const result = highlight(str, { lang: 'js' });
+    const result = highlight(str, {lang: 'js'});
     assertResult(result, gutter(1, 5), code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null), 'js');
     validateHtmlAsync(result, done);
   });
@@ -246,7 +246,7 @@ describe('highlight', () => {
       '`'
     ].join('\n');
 
-    const result = highlight(str, { autoDetect: true });
+    const result = highlight(str, {autoDetect: true});
     assertResult(result, gutter(1, 6), code('<span class="meta">"use strict"</span>;\n<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null), 'javascript');
     validateHtmlAsync(result, done);
   });
@@ -276,7 +276,7 @@ describe('highlight', () => {
       '    return false;',
       '}'
     ].join('\n');
-    const result = highlight(str, {hljs: true, lang: 'javascript' });
+    const result = highlight(str, {hljs: true, lang: 'javascript'});
     result.should.include(gutterStart);
     result.should.include(codeStart);
     result.should.include('code class="hljs javascript"');
@@ -295,7 +295,7 @@ describe('highlight', () => {
       '    return false;',
       '}'
     ].join('\n');
-    const result = highlight(str, {hljs: true, gutter: false, lang: 'javascript' });
+    const result = highlight(str, {hljs: true, gutter: false, lang: 'javascript'});
     result.should.not.include(gutterStart);
     result.should.not.include(codeStart);
     result.should.include('code class="hljs javascript"');

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -13,23 +13,22 @@ const testJson = {
 
 const testString = JSON.stringify(testJson, null, '  ');
 
-const start = '<figure class="highlight plain"><table><tr>';
-const end = '</tr></table></figure>';
-
 const gutterStart = '<td class="gutter"><pre>';
 const gutterEnd = '</pre></td>';
 
 const codeStart = '<td class="code"><pre>';
 const codeEnd = '</pre></td>';
 
-function gutter(start, end) {
-  let result = gutterStart;
+function gutter(start, end, disabled) {
+  let result = [];
 
   for (let i = start; i <= end; i++) {
-    result += `<span class="line">${i}</span><br>`;
+    if (disabled) {
+      result.push('');
+    } else {
+      result.push(gutterStart + `<span class="line">${i}</span>` + gutterEnd);
+    }
   }
-
-  result += gutterEnd;
 
   return result;
 }
@@ -47,13 +46,20 @@ function code(str, lang) {
 
   const lines = data.value.split('\n');
 
-  return lines.reduce((prev, current) => {
-    return `${prev}<span class="line">${current}</span><br>`;
-  }, codeStart) + codeEnd;
+  return lines.map(current => {
+    return codeStart + `<span class="line">${current}</span>` + codeEnd;
+  });
 }
 
-function assertResult(result, ...args) {
-  result.should.eql(start + args.join('') + end);
+function assertResult(result, gutter, code, className = 'plain', caption = '') {
+  const start = `<figure class="highlight ${className}">${caption}<table>`;
+  const end = '</table></figure>';
+  let res = start;
+  for (let i in gutter) {
+    res += '<tr>' + gutter[i] + code[i] + '</tr>';
+  }
+  res += end;
+  result.should.eql(res);
 }
 
 function validateHtmlAsync(str, done) {
@@ -81,7 +87,7 @@ describe('highlight', () => {
 
   it('gutter: false', done => {
     const result = highlight(testString, {gutter: false});
-    assertResult(result, code(testString));
+    assertResult(result, gutter(1, 4, true), code(testString));
     validateHtmlAsync(result, done);
   });
 
@@ -141,25 +147,13 @@ describe('highlight', () => {
 
   it('lang = json', done => {
     const result = highlight(testString, {lang: 'json'});
-
-    result.should.eql([
-      '<figure class="highlight json"><table><tr>',
-      gutter(1, 4),
-      code(testString, 'json'),
-      end
-    ].join(''));
+    assertResult(result, gutter(1, 4), code(testString, 'json'), 'json');
     validateHtmlAsync(result, done);
   });
 
   it('auto detect', done => {
     const result = highlight(testString, {autoDetect: true});
-
-    result.should.eql([
-      '<figure class="highlight json"><table><tr>',
-      gutter(1, 4),
-      code(testString, 'json'),
-      end
-    ].join(''));
+    assertResult(result, gutter(1, 4), code(testString, 'json'), 'json');
     validateHtmlAsync(result, done);
   });
 
@@ -176,12 +170,7 @@ describe('highlight', () => {
       caption: 'hello world'
     });
 
-    result.should.eql([
-      '<figure class="highlight plain"><figcaption>hello world</figcaption><table><tr>',
-      gutter(1, 4),
-      code(testString),
-      end
-    ].join(''));
+    assertResult(result, gutter(1, 4), code(testString), 'plain', '<figcaption>hello world</figcaption>');
     validateHtmlAsync(result, done);
   });
 
@@ -194,13 +183,7 @@ describe('highlight', () => {
     ].join('\n');
 
     const result = highlight(str, {tab: '  ', lang: 'js'});
-
-    result.should.eql([
-      '<figure class="highlight js"><table><tr>',
-      gutter(1, 4),
-      code(str.replace(/\t/g, '  '), 'js'),
-      end
-    ].join(''));
+    assertResult(result, gutter(1, 4), code(str.replace(/\t/g, '  '), 'js'), 'js');
     validateHtmlAsync(result, done);
   });
 
@@ -221,12 +204,7 @@ describe('highlight', () => {
   it('highlight sublanguages', function(done) {
     var str = '<node><?php echo "foo"; ?></node>';
     var result = highlight(str, {lang: 'xml'});
-    result.should.eql([
-      '<figure class="highlight xml"><table><tr>',
-      gutter(1, 1),
-      code('<span class="tag">&lt;<span class="name">node</span>&gt;</span><span class="php"><span class="meta">&lt;?php</span> <span class="keyword">echo</span> <span class="string">"foo"</span>; <span class="meta">?&gt;</span></span><span class="tag">&lt;/<span class="name">node</span>&gt;</span>', null),
-      end
-    ].join(''));
+    assertResult(result, gutter(1, 1), code('<span class="tag">&lt;<span class="name">node</span>&gt;</span><span class="php"><span class="meta">&lt;?php</span> <span class="keyword">echo</span> <span class="string">"foo"</span>; <span class="meta">?&gt;</span></span><span class="tag">&lt;/<span class="name">node</span>&gt;</span>', null), 'xml');
     validateHtmlAsync(result, done);
   });
 
@@ -239,13 +217,8 @@ describe('highlight', () => {
       '`'
     ].join('\n');
 
-    const result = highlight(str, {lang: 'js'});
-    result.should.eql([
-      '<figure class="highlight js"><table><tr>',
-      gutter(1, 5),
-      code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string">  line</span>\n<span class="string">  string</span>\n<span class="string">`</span>', null),
-      end
-    ].join(''));
+    const result = highlight(str, { lang: 'js' });
+    assertResult(result, gutter(1, 5), code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string">  line</span>\n<span class="string">  string</span>\n<span class="string">`</span>', null), 'js');
     validateHtmlAsync(result, done);
   });
 
@@ -258,13 +231,8 @@ describe('highlight', () => {
       '`'
     ].join('\n');
 
-    const result = highlight(str, {lang: 'js'});
-    result.should.eql([
-      '<figure class="highlight js"><table><tr>',
-      gutter(1, 5),
-      code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null),
-      end
-    ].join(''));
+    const result = highlight(str, { lang: 'js' });
+    assertResult(result, gutter(1, 5), code('<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null), 'js');
     validateHtmlAsync(result, done);
   });
 
@@ -278,13 +246,8 @@ describe('highlight', () => {
       '`'
     ].join('\n');
 
-    const result = highlight(str, {autoDetect: true});
-    result.should.eql([
-      '<figure class="highlight javascript"><table><tr>',
-      gutter(1, 6),
-      code('<span class="meta">"use strict"</span>;\n<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null),
-      end
-    ].join(''));
+    const result = highlight(str, { autoDetect: true });
+    assertResult(result, gutter(1, 6), code('<span class="meta">"use strict"</span>;\n<span class="keyword">var</span> string = <span class="string">`</span>\n<span class="string">  Multi</span>\n<span class="string"></span>\n<span class="string">  string</span>\n<span class="string">`</span>', null), 'javascript');
     validateHtmlAsync(result, done);
   });
 
@@ -318,7 +281,9 @@ describe('highlight', () => {
     result.should.include(codeStart);
     result.should.include('code class="hljs javascript"');
     result.should.include('class="hljs-function"');
-    result.should.include(gutter(1, 5));
+    gutter(1, 5).every(line => {
+      result.should.include(line);
+    });
     validateHtmlAsync(result, done);
   });
 

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -201,7 +201,7 @@ describe('highlight', () => {
     validateHtmlAsync(result, done);
   });
 
-  it('highlight sublanguages', function(done) {
+  it('highlight sublanguages', done => {
     var str = '<node><?php echo "foo"; ?></node>';
     var result = highlight(str, {lang: 'xml'});
     assertResult(result, gutter(1, 1), code('<span class="tag">&lt;<span class="name">node</span>&gt;</span><span class="php"><span class="meta">&lt;?php</span> <span class="keyword">echo</span> <span class="string">"foo"</span>; <span class="meta">?&gt;</span></span><span class="tag">&lt;/<span class="name">node</span>&gt;</span>', null), 'xml');
@@ -268,7 +268,7 @@ describe('highlight', () => {
     validateHtmlAsync(result, done);
   });
 
-  it('hljs compatibility - with lines', (done) => {
+  it('hljs compatibility - with lines', done => {
     const str = [
       'function (a) {',
       '    if (a > 3)',
@@ -282,12 +282,12 @@ describe('highlight', () => {
     result.should.include('code class="hljs javascript"');
     result.should.include('class="hljs-function"');
     gutter(1, 5).every(line => {
-      result.should.include(line);
+      return result.should.include(line);
     });
     validateHtmlAsync(result, done);
   });
 
-  it('hljs compatibility - no lines', (done) => {
+  it('hljs compatibility - no lines', done => {
     const str = [
       'function (a) {',
       '    if (a > 3)',


### PR DESCRIPTION
## Current behavior
```html
<tr>
  <td class="gutter"><pre>
    <span class="line">1</span>
    <br>
    <span class="line">2</span>
    <br>
    <span class="line">3</span>
  </pre></td>

  <td class="code"><pre>
    <span class="line">hello, world</pre>
    <br>
    <span class="line">hello, world</span>
    <br>
    <span class="line">hello, world</span>
  </pre></td>
</tr>
```

## New behavior
```html
<tr>
  <td class="gutter"><pre>
    <span class="line">1</span>
  </pre></td>
  <td class="code"><pre>
    <span class="line">hello, world</pre>
  </td>
</tr>

<tr>
  <td class="gutter"><pre>
    <span class="line">2</span>
  </pre></td>
  <td class="code"><pre>
    <span class="line">hello, world</pre>
  </td>
</tr>

<tr>
  <td class="gutter"><pre>
    <span class="line">3</span>
  </pre></td>
  <td class="code"><pre>
    <span class="line">hello, world</pre>
  </td>
</tr>
```