### PR TITLE
feat: apply pretty_url to url_for & full_url_for

### DIFF
--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -14,6 +14,13 @@ function fullUrlForHelper(path = '/') {
   if (data.hostname !== sitehost || data.origin === 'null') return path;
 
   path = encodeURL(config.url + `/${path}`.replace(/\/{2,}/g, '/'));
+
+  const { trailing_index } = Object.assign({
+    trailing_index: true
+  }, config.pretty_url);
+
+  if (!trailing_index) path = path.replace(/index\.html$/, '');
+
   return path;
 }
 

--- a/lib/url_for.js
+++ b/lib/url_for.js
@@ -5,9 +5,7 @@ const encodeURL = require('./encode_url');
 const relative_url = require('./relative_url');
 
 function urlForHelper(path = '/', options) {
-  if (path.startsWith('#') || path.startsWith('//')) {
-    return path;
-  }
+  if (path.startsWith('#') || path.startsWith('//')) return path;
 
   const { config } = this;
   const { root } = config;
@@ -28,6 +26,12 @@ function urlForHelper(path = '/', options) {
 
   // Prepend root path
   path = encodeURL((root + path).replace(/\/{2,}/g, '/'));
+
+  const { trailing_index } = Object.assign({
+    trailing_index: true
+  }, config.pretty_url);
+
+  if (!trailing_index) path = path.replace(/index\.html$/, '');
 
   return path;
 }

--- a/test/full_url_for.spec.js
+++ b/test/full_url_for.spec.js
@@ -26,10 +26,23 @@ describe('full_url_for', () => {
     fullUrlFor('/index.html').should.eql('https://example.com/index.html');
   });
 
+  it('internal url - pretty_url.trailing_index disabled', () => {
+    ctx.config.url = 'https://example.com';
+    ctx.config.pretty_url = {
+      trailing_index: false
+    };
+
+    fullUrlFor('index.html').should.eql(ctx.config.url + '/');
+    fullUrlFor('/').should.eql(ctx.config.url + '/');
+  });
+
+
   it('external url', () => {
     [
       'https://hexo.io/',
-      '//google.com/'
+      '//google.com/',
+      // url_for shouldn't process external link even if trailing_index is disabled.
+      'https://hexo.io/docs/index.html'
     ].forEach(url => {
       fullUrlFor(url).should.eql(url);
     });

--- a/test/url_for.spec.js
+++ b/test/url_for.spec.js
@@ -62,10 +62,28 @@ describe('url_for', () => {
     ctx.config.relative_link = false;
   });
 
+  it('internal url (pretty_url.trailing_index disabled)', () => {
+    ctx.config.root = '/';
+    ctx.config.pretty_url = {
+      trailing_index: false
+    };
+
+    urlFor('index.html').should.eql('/');
+    urlFor('/').should.eql('/');
+    urlFor('/index.html').should.eql('/');
+
+    ctx.config.root = '/blog/';
+    urlFor('index.html').should.eql('/blog/');
+    urlFor('/').should.eql('/blog/');
+    urlFor('/index.html').should.eql('/blog/');
+  });
+
   it('external url', () => {
     [
       'https://hexo.io/',
-      '//google.com/'
+      '//google.com/',
+      // url_for shouldn't process external link even if trailing_index is disabled.
+      'https://hexo.io/docs/index.html'
     ].forEach(url => {
       urlFor(url).should.eql(url);
     });


### PR DESCRIPTION
I have noticed `url_for` & `full_url_for` will not remove `index.html` while `trailing_index` is disabled. This PR is addressed to make the `trailing_index` behavior more consistent. 

I haven't apply pretty_url options to `relative_url()` yet because relative_url doesn't require `bind(hexo)` and can not read `hexo.config` directly. After we finish `relative_url()` I will make this PR "Ready to Review".