### PR TITLE
fix(highlight): decouple 'wrap' and 'hljs'

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -24,7 +24,6 @@ function highlightUtil(str, options = {}) {
   const lang = options.lang || data.language || '';
   const classNames = (useHljs ? 'hljs' : 'highlight') + (lang ? ` ${lang}` : '');
 
-  if (useHljs && !gutter) wrap = false;
   if (gutter && !wrap) wrap = true; // arbitrate conflict ("gutter:true" takes priority over "wrap:false")
 
   const before = useHljs ? `<pre><code class="${classNames}">` : '<pre>';

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -295,9 +295,25 @@ describe('highlight', () => {
       '    return false;',
       '}'
     ].join('\n');
-    const result = highlight(str, {hljs: true, gutter: false, lang: 'javascript'});
+    const result = highlight(str, {hljs: true, gutter: false, wrap: false, lang: 'javascript'});
     result.should.not.include(gutterStart);
     result.should.not.include(codeStart);
+    result.should.include('code class="hljs javascript"');
+    result.should.include('class="hljs-function"');
+    validateHtmlAsync(result, done);
+  });
+
+  it('hljs compatibility - wrap is true', done => {
+    const str = [
+      'function (a) {',
+      '    if (a > 3)',
+      '        return true;',
+      '    return false;',
+      '}'
+    ].join('\n');
+    const result = highlight(str, {hljs: true, gutter: false, wrap: true, lang: 'javascript'});
+    result.should.not.include(gutterStart);
+    result.should.include(codeStart);
     result.should.include('code class="hljs javascript"');
     result.should.include('class="hljs-function"');
     validateHtmlAsync(result, done);


### PR DESCRIPTION
Currently, enabling `hljs` always disable `wrap`, but I noticed that it is actually not necessary. I tested `hljs: true` + `wrap: true` with [darcula theme](https://github.com/highlightjs/highlight.js/blob/master/src/styles/darcula.css), code highlighting works fine.

Noticed while testing https://github.com/hexojs/hexo/pull/3865

---

``` yml
line_number: true # or gutter: true
hljs: true
wrap: false
```

Since enabling `line_number` will also enable `wrap`, this behavior doesn't change.

---

``` yml
line_number: false
hljs: true
wrap: true
```

With this PR, it is possible to enable both `hljs` and `wrap`, so user can use `hljs-*` prefix in css classes while wrapping the codeblock in `<table>`. This can make upgrading the hljs syntax slightly easier.