### PR TITLE
Fix parsing placeholder with trailing underscore at "new_post_name"

### DIFF
--- a/lib/permalink.js
+++ b/lib/permalink.js
@@ -2,7 +2,7 @@
 
 const escapeRegExp = require('./escape_regexp');
 
-const rParam = /:(\w+)/g;
+const rParam = /:(\w*[^_\W])/g;
 
 function Permalink(rule, options) {
   if (!rule) throw new TypeError('rule is required!');

--- a/test/permalink.spec.js
+++ b/test/permalink.spec.js
@@ -13,6 +13,12 @@ describe('Permalink', () => {
     permalink.regex.should.eql(/^(.+?)\/(.+?)\/(.+?)\/(.+?)$/);
     permalink.params.should.eql(['year', 'month', 'day', 'title']);
 
+    permalink = new Permalink(':year_:i_month_:i_day_:title');
+
+    permalink.rule.should.eql(':year_:i_month_:i_day_:title');
+    permalink.regex.should.eql(/^(.+?)_(.+?)_(.+?)_(.+?)$/);
+    permalink.params.should.eql(['year', 'i_month', 'i_day', 'title']);
+
     permalink = new Permalink(':year/:month/:day/:title', {
       segments: {
         year: /(\d{4})/,


### PR DESCRIPTION
Fix issue hexojs/hexo#3862

In `_config.yml`, the item `new_post_name:` takes a template string which includes placeholders.
The placeholders are such as `:title`, `:year`, `:i_day`.

The name of placeholders consists of alphanumeric characters and underscores.
But the last character should not be an underscore.
That is, trailing underscores of a placeholder should not be parsed as a part of the placeholder.

This patch fixes the RegExp to parse a placeholder.
