### PR TITLE
refactor(isExternallink): no longer needs bind(hexo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Utilities for [Hexo].
 - [hash](#hashstr)
 - [highlight](#highlightstr-options)
 - [htmlTag](#htmltagtag-attrs-text-escape)
-- [isExternalLink](#isexternallinkurl)
+- [isExternalLink](#isexternallinkurl-sitehost-exclude)
 - [Pattern](#patternrule)
 - [Permalink](#permalinkrule-options)
 - [relative_url](#relative_urlfrom-to)
@@ -255,38 +255,39 @@ htmlTag('script', {src: '/foo.js', async: true}, '')
 // <script src="/foo.js" async></script>
 ```
 
-### isExternalLink(url)
+### isExternalLink(url, sitehost, [exclude])
 
-Returns if a given url is external link relative to `config.url` and `config.exclude`.
+Option | Description | Default
+--- | --- | ---
+`url` | The input URL. |
+`sitehost` | The hostname / url of website. You can also pass `hexo.config.url`. |
+`exclude` | Exclude hostnames. Specific subdomain is required when applicable, including www. | `[]`
 
-``` yml
-_config.yml
-url: https://example.com # example
+Returns if a given url is external link relative to given `sitehost` and `[exclude]`.
+
+``` js
+// 'sitehost' can be a domain or url
+isExternalLink('https://example.com', 'example.com');
+// false
+isExternalLink('https://example.com', 'https://example.com');
+// false
+isExternalLink('https://example.com', '//example.com/blog/');
+// false
 ```
 
 ``` js
-isExternalLink('https://example.com');
+isExternalLink('/archives/foo.html', 'example.com');
 // false
-isExternalLink('/archives/foo.html');
-// false
-isExternalLink('https://foo.com/');
+isExternalLink('https://foo.com/', 'example.com');
 // true
 ```
 
-``` yml
-_config.yml
-url: https://example.com # example
-exclude:
-  - foo.com
-  - bar.com
-```
-
 ``` js
-isExternalLink('https://foo.com');
+isExternalLink('https://foo.com', 'example.com', ['foo.com', 'bar.com']);
 // false
-isExternalLink('https://bar.com');
+isExternalLink('https://bar.com', 'example.com', ['foo.com', 'bar.com']);
 // false
-isExternalLink('https://baz.com/');
+isExternalLink('https://baz.com/', 'example.com', ['foo.com', 'bar.com']);
 // true
 ```
 
@@ -486,7 +487,6 @@ Following utilities require `bind(hexo)` / `bind(this)` / `call(hexo, input)` / 
 - [`full_url_for()`](#full_url_forpath)
 - [`url_for()`](#url_forpath)
 - [`relative_url()`](#relative_urlfrom-to)
-- [`isExternalLink()`](#isexternallinkurl)
 
 Below examples demonstrate different approaches to creating a [helper](https://hexo.io/api/helper) (each example is separated by `/******/`),
 

--- a/lib/is_external_link.js
+++ b/lib/is_external_link.js
@@ -8,9 +8,9 @@ const { parse, URL } = require('url');
  * @returns {Boolean} True if the link doesn't have protocol or link has same host with config.url
  */
 
-function isExternalLink(input) {
-  const { config } = this;
-  const sitehost = parse(config.url).hostname || config.url;
+function isExternalLink(input, sitehost, exclude) {
+  sitehost = parse(sitehost).hostname || sitehost;
+
   if (!sitehost) return false;
 
   // handle relative url
@@ -21,9 +21,8 @@ function isExternalLink(input) {
 
   const host = data.hostname;
 
-  if (config.external_link && config.external_link.exclude) {
-    const exclude = Array.isArray(config.external_link.exclude) ? config.external_link.exclude
-      : [config.external_link.exclude];
+  if (exclude) {
+    exclude = Array.isArray(exclude) ? exclude : [exclude];
 
     if (exclude && exclude.length) {
       for (const i of exclude) {

--- a/test/is_external_link.spec.js
+++ b/test/is_external_link.spec.js
@@ -7,47 +7,47 @@ describe('isExternalLink', () => {
     }
   };
 
-  const isExternalLink = require('../lib/is_external_link').bind(ctx);
+  const isExternalLink = require('../lib/is_external_link');
 
   it('external link', () => {
-    isExternalLink('https://hexo.io/').should.eql(true);
+    isExternalLink('https://hexo.io/', ctx.config.url).should.eql(true);
   });
 
   it('internal link', () => {
-    isExternalLink('https://example.com').should.eql(false);
-    isExternalLink('//example.com').should.eql(false);
-    isExternalLink('//example.com/archives/foo.html').should.eql(false);
-    isExternalLink('/archives/foo.html').should.eql(false);
+    isExternalLink('https://example.com', ctx.config.url).should.eql(false);
+    isExternalLink('//example.com', ctx.config.url).should.eql(false);
+    isExternalLink('//example.com/archives/foo.html', ctx.config.url).should.eql(false);
+    isExternalLink('/archives/foo.html', ctx.config.url).should.eql(false);
   });
 
   it('hash, mailto, javascript', () => {
-    isExternalLink('#top').should.eql(false);
-    isExternalLink('mailto:hi@hexo.io').should.eql(false);
-    isExternalLink('javascript:alert(\'Hexo is Awesome\')').should.eql(false);
+    isExternalLink('#top', ctx.config.url).should.eql(false);
+    isExternalLink('mailto:hi@hexo.io', ctx.config.url).should.eql(false);
+    isExternalLink('javascript:alert(\'Hexo is Awesome\')', ctx.config.url).should.eql(false);
   });
 
   it('exclude - empty string', () => {
     ctx.config.external_link = {
       exclude: ''
     };
-    isExternalLink('https://hexo.io/').should.eql(true);
+    isExternalLink('https://hexo.io/', ctx.config.url, ctx.config.external_link.exclude).should.eql(true);
   });
 
   it('exclude - string', () => {
     ctx.config.external_link = {
       exclude: 'foo.com'
     };
-    isExternalLink('https://foo.com/').should.eql(false);
-    isExternalLink('https://bar.com/').should.eql(true);
-    isExternalLink('https://baz.com/').should.eql(true);
+    isExternalLink('https://foo.com/', ctx.config.url, ctx.config.external_link.exclude).should.eql(false);
+    isExternalLink('https://bar.com/', ctx.config.url, ctx.config.external_link.exclude).should.eql(true);
+    isExternalLink('https://baz.com/', ctx.config.url, ctx.config.external_link.exclude).should.eql(true);
   });
 
   it('exclude - array', () => {
     ctx.config.external_link = {
       exclude: ['foo.com', 'bar.com']
     };
-    isExternalLink('https://foo.com/').should.eql(false);
-    isExternalLink('https://bar.com/').should.eql(false);
-    isExternalLink('https://baz.com/').should.eql(true);
+    isExternalLink('https://foo.com/', ctx.config.url, ctx.config.external_link.exclude).should.eql(false);
+    isExternalLink('https://bar.com/', ctx.config.url, ctx.config.external_link.exclude).should.eql(false);
+    isExternalLink('https://baz.com/', ctx.config.url, ctx.config.external_link.exclude).should.eql(true);
   });
 });


### PR DESCRIPTION
## BREAKING CHANGES

In order to better utilizing `isExternalLink()`, this PR makes `isExternalLink()` no longer requires `bind(hexo)`. `sitehost` & `exclude` will need to be passed after this PR.

**Affected code:**

https://github.com/hexojs/hexo/pull/3835, https://github.com/hexojs/hexo/pull/3847: New parameters will be needed.

[hexo-filter-nofollow](https://github.com/hexojs/hexo-filter-nofollow), https://github.com/hexojs/hexo-renderer-marked/pull/116, https://github.com/hexojs/hexo-renderer-marked/pull/119: `hexo-filter-nofollow` and `hexo-renderer-marked` will be able to utilize `isExternalLink()`.

