### PR TITLE
fix(url_for/full_url_for): do not process absolute url

### DIFF
--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -4,7 +4,8 @@ const { parse, URL } = require('url');
 const encodeURL = require('./encode_url');
 
 function fullUrlForHelper(path = '/') {
-  if (path.startsWith('//')) return path;
+  const pathRegex = /^(\/\/|http(s)?:)/;
+  if (pathRegex.test(path)) return path;
 
   const { config } = this;
   const sitehost = parse(config.url).hostname || config.url;

--- a/lib/url_for.js
+++ b/lib/url_for.js
@@ -5,7 +5,8 @@ const encodeURL = require('./encode_url');
 const relative_url = require('./relative_url');
 
 function urlForHelper(path = '/', options) {
-  if (path.startsWith('#') || path.startsWith('//')) return path;
+  const pathRegex = /^(#|\/\/|http(s)?:)/;
+  if (pathRegex.test(path)) return path;
 
   const { config } = this;
   const { root } = config;

--- a/test/full_url_for.spec.js
+++ b/test/full_url_for.spec.js
@@ -37,12 +37,15 @@ describe('full_url_for', () => {
   });
 
 
-  it('external url', () => {
+  it('absolute url', () => {
     [
       'https://hexo.io/',
       '//google.com/',
       // url_for shouldn't process external link even if trailing_index is disabled.
-      'https://hexo.io/docs/index.html'
+      'https://hexo.io/docs/index.html',
+      // shouldn't process internal absolute url
+      'http://example.com/foo/bar/',
+      'https://example.com/foo/bar/'
     ].forEach(url => {
       fullUrlFor(url).should.eql(url);
     });

--- a/test/url_for.spec.js
+++ b/test/url_for.spec.js
@@ -78,12 +78,15 @@ describe('url_for', () => {
     urlFor('/index.html').should.eql('/blog/');
   });
 
-  it('external url', () => {
+  it('absolute url', () => {
     [
       'https://hexo.io/',
       '//google.com/',
       // url_for shouldn't process external link even if trailing_index is disabled.
-      'https://hexo.io/docs/index.html'
+      'https://hexo.io/docs/index.html',
+      // shouldn't process internal absolute url
+      'http://example.com/foo/bar/',
+      'https://example.com/foo/bar/'
     ].forEach(url => {
       urlFor(url).should.eql(url);
     });


### PR DESCRIPTION
Noticed an edge case while testing https://github.com/hexojs/hexo-renderer-marked/pull/124

``` js
const ctx = {
  config: {
    url: 'http://example.com',
    root: '/goal/'
  }
}

console.log(url_for.call(ctx, 'http://example.com/hash/bob.html'))
// /goal/http:/example.com/hash/bob.html
```

---

`ReExp.test()` is slightly faster than `String.startsWith()/String.endsWith()` and easier to add a new pattern.