### PR TITLE
revert: feat(highlight): adjust the layout of the highlight code block

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -2,7 +2,6 @@
 
 const hljs = require('highlight.js');
 const alias = require('../highlight_alias.json');
-
 const escapeHTML = require('./escape_html');
 
 function highlightUtil(str, options = {}) {
@@ -31,29 +30,31 @@ function highlightUtil(str, options = {}) {
 
   if (!wrap) return `<pre><code class="${classNames}">${data.value}</code></pre>`;
 
+  const lines = data.value.split('\n');
+  let numbers = '';
+  let content = '';
+
+  for (let i = 0, len = lines.length; i < len; i++) {
+    let line = lines[i];
+    if (tab) line = replaceTabs(line, tab);
+    numbers += `<span class="line">${Number(firstLine) + i}</span><br>`;
+    content += formatLine(line, Number(firstLine) + i, mark, options);
+  }
+
   let result = `<figure class="highlight${data.language ? ` ${data.language}` : ''}">`;
 
   if (caption) {
     result += `<figcaption>${caption}</figcaption>`;
   }
 
-  result += '<table>';
+  result += '<table><tr>';
 
-  const lines = data.value.split('\n');
-
-  for (let i = 0, len = lines.length; i < len; i++) {
-    let line = lines[i];
-    if (tab) line = replaceTabs(line, tab);
-    let content = formatLine(line, Number(firstLine) + i, mark, options);
-
-    result += '<tr>';
-    if (gutter) {
-      result += `<td class="gutter"><pre><span class="line">${Number(firstLine) + i}</span></pre></td>`;
-    }
-    result += `<td class="code">${before}${content}${after}</td></tr>`;
+  if (gutter) {
+    result += `<td class="gutter"><pre>${numbers}</pre></td>`;
   }
 
-  result += '</table></figure>';
+  result += `<td class="code">${before}${content}${after}</td>`;
+  result += '</tr></table></figure>';
 
   return result;
 }
@@ -68,6 +69,7 @@ function formatLine(line, lineno, marked, options) {
     res += useHljs ? line : `">${line}</span>`;
   }
 
+  res += '<br>';
   return res;
 }
 


### PR DESCRIPTION
In this PR I just simply revert #132 because #132 introduces just too much Breaking Changes, see discussion at https://github.com/hexojs/hexo-util/pull/132 and related issue #145. 

IMHO, we should not bring any style changes in highlightjs any more. It will break too much things, especially when we are going to deprecate highlightjs and bring up prismjs.

Hexo has nearly 300 themes, "NexT theme works fine" is just not an enough excuse.

cc @jiangtj @stevenjoezhang @ppoffice