### PR TITLE
feat(cache): enable lru cache

### DIFF
--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -4,8 +4,8 @@ const { parse, URL } = require('url');
 const encodeURL = require('./encode_url');
 const prettyUrls = require('./pretty_urls');
 
-const LFU = require('node-lfu-cache');
-const cache = new LFU(100);
+const LRU = require('lru-cache');
+const cache = new LRU(100);
 
 function fullUrlForHelper(path = '/') {
   const pathRegex = /^(\/\/|http(s)?:)/;

--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -4,11 +4,24 @@ const { parse, URL } = require('url');
 const encodeURL = require('./encode_url');
 const prettyUrls = require('./pretty_urls');
 
+const LFU = require('node-lfu-cache');
+const cache = new LFU(100);
+
 function fullUrlForHelper(path = '/') {
   const pathRegex = /^(\/\/|http(s)?:)/;
   if (pathRegex.test(path)) return path;
 
   const { config } = this;
+  const prettyUrlsOptions = Object.assign({
+    trailing_index: true,
+    trailing_html: true
+  }, config.pretty_urls);
+
+  // cacheId is designed to works across different hexo.config & options
+  const cacheId = `${config.url}-${prettyUrlsOptions.trailing_index}-${prettyUrlsOptions.trailing_html}-${path}`;
+
+  if (cache.has(cacheId)) return cache.get(cacheId);
+
   const sitehost = parse(config.url).hostname || config.url;
   const data = new URL(path, `http://${sitehost}`);
 
@@ -17,13 +30,9 @@ function fullUrlForHelper(path = '/') {
 
   path = encodeURL(config.url + `/${path}`.replace(/\/{2,}/g, '/'));
 
-  const prettyUrlsOptions = Object.assign({
-    trailing_index: true,
-    trailing_html: true
-  }, config.pretty_urls);
-
   path = prettyUrls(path, prettyUrlsOptions);
 
+  cache.set(cacheId, path);
   return path;
 }
 

--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -2,6 +2,8 @@
 
 const { createHash } = require('crypto');
 const { stringify } = require('querystring');
+const LFU = require('node-lfu-cache');
+const cache = new LFU(20);
 
 function md5(str) {
   return createHash('md5').update(str).digest('hex');
@@ -12,11 +14,15 @@ function gravatarHelper(email, options) {
     options = {s: options};
   }
 
-  let str = `https://www.gravatar.com/avatar/${md5(email.toLowerCase())}`;
   const qs = stringify(options);
+  const cacheId = `${email}-${qs}`;
 
+  if (cache.has(cacheId)) return cache.get(cacheId);
+
+  let str = `https://www.gravatar.com/avatar/${md5(email.toLowerCase())}`;
   if (qs) str += `?${qs}`;
 
+  cache.set(cacheId, str);
   return str;
 }
 

--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -2,8 +2,8 @@
 
 const { createHash } = require('crypto');
 const { stringify } = require('querystring');
-const LFU = require('node-lfu-cache');
-const cache = new LFU(5);
+const LRU = require('lru-cache');
+const cache = new LRU(5);
 
 function md5(str) {
   return createHash('md5').update(str).digest('hex');

--- a/lib/gravatar.js
+++ b/lib/gravatar.js
@@ -3,7 +3,7 @@
 const { createHash } = require('crypto');
 const { stringify } = require('querystring');
 const LFU = require('node-lfu-cache');
-const cache = new LFU(20);
+const cache = new LFU(5);
 
 function md5(str) {
   return createHash('md5').update(str).digest('hex');

--- a/lib/is_external_link.js
+++ b/lib/is_external_link.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const { parse, URL } = require('url');
+const LFU = require('node-lfu-cache');
+const cache = new LFU(100);
 
 /**
  * Check whether the link is external
@@ -13,10 +15,15 @@ function isExternalLink(input, sitehost, exclude) {
 
   if (!sitehost) return false;
 
+  const cacheId = `${input}-${sitehost}-${exclude}`;
+
+  if (cache.has(cacheId)) return cache.get(cacheId);
+
   // handle relative url
   const data = new URL(input, `http://${sitehost}`);
 
   // handle mailto: javascript: vbscript: and so on
+  cache.set(cacheId, false);
   if (data.origin === 'null') return false;
 
   const host = data.hostname;
@@ -26,13 +33,16 @@ function isExternalLink(input, sitehost, exclude) {
 
     if (exclude && exclude.length) {
       for (const i of exclude) {
+        cache.set(cacheId, false);
         if (host === i) return false;
       }
     }
   }
 
+  cache.set(cacheId, true);
   if (host !== sitehost) return true;
 
+  cache.set(cacheId, false);
   return false;
 }
 

--- a/lib/is_external_link.js
+++ b/lib/is_external_link.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const { parse, URL } = require('url');
-const LFU = require('node-lfu-cache');
-const cache = new LFU(100);
+const LRU = require('lru-cache');
+const cache = new LRU(100);
 
 /**
  * Check whether the link is external

--- a/lib/relative_url.js
+++ b/lib/relative_url.js
@@ -2,7 +2,7 @@
 
 const encodeURL = require('./encode_url');
 const LFU = require('node-lfu-cache');
-const cache = new LFU(100);
+const cache = new LFU(50);
 
 function relativeUrlHelper(from = '', to = '') {
   const cacheId = `${from}-${to}`;

--- a/lib/relative_url.js
+++ b/lib/relative_url.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const encodeURL = require('./encode_url');
-const LFU = require('node-lfu-cache');
-const cache = new LFU(50);
+const LRU = require('lru-cache');
+const cache = new LRU(50);
 
 function relativeUrlHelper(from = '', to = '') {
   const cacheId = `${from}-${to}`;

--- a/lib/relative_url.js
+++ b/lib/relative_url.js
@@ -1,8 +1,14 @@
 'use strict';
 
 const encodeURL = require('./encode_url');
+const LFU = require('node-lfu-cache');
+const cache = new LFU(100);
 
 function relativeUrlHelper(from = '', to = '') {
+  const cacheId = `${from}-${to}`;
+
+  if (cache.has(cacheId)) return cache.get(cacheId);
+
   const fromParts = from.split('/');
   const toParts = to.split('/');
   const length = Math.min(fromParts.length, toParts.length);
@@ -25,7 +31,9 @@ function relativeUrlHelper(from = '', to = '') {
     out = out.slice(0, outLength - 2).concat('index.html');
   }
 
-  return encodeURL(out.join('/').replace(/\/{2,}/g, '/'));
+  const result = encodeURL(out.join('/').replace(/\/{2,}/g, '/'));
+  cache.set(cacheId, result);
+  return result;
 }
 
 module.exports = relativeUrlHelper;

--- a/lib/url_for.js
+++ b/lib/url_for.js
@@ -5,8 +5,8 @@ const encodeURL = require('./encode_url');
 const relative_url = require('./relative_url');
 const prettyUrls = require('./pretty_urls');
 
-const LFU = require('node-lfu-cache');
-const cache = new LFU(100);
+const LRU = require('lru-cache');
+const cache = new LRU(100);
 
 function urlForHelper(path = '/', options) {
   const pathRegex = /^(#|\/\/|http(s)?:)/;

--- a/lib/url_for.js
+++ b/lib/url_for.js
@@ -5,37 +5,47 @@ const encodeURL = require('./encode_url');
 const relative_url = require('./relative_url');
 const prettyUrls = require('./pretty_urls');
 
+const LFU = require('node-lfu-cache');
+const cache = new LFU(100);
+
 function urlForHelper(path = '/', options) {
   const pathRegex = /^(#|\/\/|http(s)?:)/;
   if (pathRegex.test(path)) return path;
 
   const { config } = this;
   const { root } = config;
-  const sitehost = parse(config.url).hostname || config.url;
-  const data = new URL(path, `http://${sitehost}`);
-
-  // Exit if input is an external link or a data url
-  if (data.hostname !== sitehost || data.origin === 'null') return path;
 
   options = Object.assign({
     relative: config.relative_link
   }, options);
 
-  // Resolve relative url
+  // Resolve & return relative url before being cached
   if (options.relative) {
     return relative_url(this.path, path);
   }
-
-  // Prepend root path
-  path = encodeURL((root + path).replace(/\/{2,}/g, '/'));
 
   const prettyUrlsOptions = Object.assign({
     trailing_index: true,
     trailing_html: true
   }, config.pretty_urls);
 
+  // cacheId is designed to works across different hexo.config & options
+  const cacheId = `${config.url}-${root}-${prettyUrlsOptions.trailing_index}-${prettyUrlsOptions.trailing_html}-${path}`;
+
+  if (cache.has(cacheId)) return cache.get(cacheId);
+
+  const sitehost = parse(config.url).hostname || config.url;
+  const data = new URL(path, `http://${sitehost}`);
+
+  // Exit if input is an external link or a data url
+  if (data.hostname !== sitehost || data.origin === 'null') return path;
+
+  // Prepend root path
+  path = encodeURL((root + path).replace(/\/{2,}/g, '/'));
+
   path = prettyUrls(path, prettyUrlsOptions);
 
+  cache.set(cacheId, path);
   return path;
 }
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cross-spawn": "^7.0.0",
     "deepmerge": "^4.2.2",
     "highlight.js": "^9.13.1",
+    "node-lfu-cache": "^5.0.0",
     "punycode.js": "^2.1.0",
     "striptags": "^3.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cross-spawn": "^7.0.0",
     "deepmerge": "^4.2.2",
     "highlight.js": "^9.13.1",
-    "node-lfu-cache": "^5.0.0",
+    "lru-cache": "^5.1.1",
     "punycode.js": "^2.1.0",
     "striptags": "^3.1.1"
   },


### PR DESCRIPTION
I have setup a stat by adding a few line of the code to `node_modules/hexo` in my local dummy site:

```js
let num = 0;

// .....
num++;
console.log(num);
```

It turns out that even as few as 17 posts in [hexo-theme-unit-test](https://github.com/hexojs/hexo-theme-unit-test), `full_url_for()` helper will be called for 537 times and `isExternalLink()` will be called for 2599 times in one generation!

So I bring up this PR. The `node-lfu-cache` is enabled for those functions:

- full_url_for()
- gravatar()
- is_external_link()
- relative_url()
- url_for()
