### PR TITLE
fix(html_tag): encode urls in meta tag

### DIFF
--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -3,6 +3,7 @@
 const encodeURL = require('./encode_url');
 const escapeHTML = require('./escape_html');
 const regexUrl = /(cite|download|href|src|url)$/i;
+const regexMeta = /^(og:|twitter:)(audio|image|image|url|video)(:secure_url)?$/i;
 
 function encSrcset(str) {
   str.split(' ')
@@ -23,8 +24,10 @@ function htmlTag(tag, attrs, text, escape = true) {
   for (const i in attrs) {
     if (attrs[i] === null || typeof attrs[i] === 'undefined') result += '';
     else {
-      if (i.match(regexUrl)) result += ` ${escapeHTML(i)}="${encodeURL(attrs[i])}"`;
-      else if (attrs[i] === true || i === attrs[i]) result += ` ${escapeHTML(i)}`;
+      if (i.match(regexUrl)
+        || (tag === 'meta' && !attrs[i].match(regexMeta) && Object.values(attrs)[0].match(regexMeta))) {
+        result += ` ${escapeHTML(i)}="${encodeURL(attrs[i])}"`;
+      } else if (attrs[i] === true || i === attrs[i]) result += ` ${escapeHTML(i)}`;
       else if (i.match(/srcset$/i)) result += ` ${escapeHTML(i)}="${encSrcset(attrs[i])}"`;
       else result += ` ${escapeHTML(i)}="${escapeHTML(String(attrs[i]))}"`;
     }

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -3,7 +3,7 @@
 const encodeURL = require('./encode_url');
 const escapeHTML = require('./escape_html');
 const regexUrl = /(cite|download|href|src|url)$/i;
-const regexMeta = /^(og:|twitter:)(audio|image|image|url|video)(:secure_url)?$/i;
+const regexMeta = /^(og:|twitter:)(audio|image|url|video)(:secure_url)?$/i;
 
 function encSrcset(str) {
   str.split(' ')

--- a/test/html_tag.spec.js
+++ b/test/html_tag.spec.js
@@ -4,6 +4,7 @@ require('chai').should();
 
 describe('htmlTag', () => {
   const htmlTag = require('../lib/html_tag');
+  const encodeURL = require('../lib/encode_url');
 
   it('tag', () => {
     htmlTag('hr').should.eql('<hr>');
@@ -112,5 +113,42 @@ describe('htmlTag', () => {
       src: '/foo.js',
       async: true
     }, '').should.eql('<script src="/foo.js" async></script>');
+  });
+
+  it('meta tag', () => {
+    htmlTag('meta', {
+      property: 'og:title',
+      content: 'foo & bar'
+    }).should.eql('<meta property="og:title" content="foo &amp; bar">');
+
+    htmlTag('meta', {
+      name: 'twitter:title',
+      content: 'foo " bar'
+    }).should.eql('<meta name="twitter:title" content="foo &quot; bar">');
+  });
+
+  it('meta tag - url', () => {
+    const content = 'https://foo.com/bár.jpg';
+    const encoded = encodeURL(content);
+
+    htmlTag('meta', {
+      property: 'og:url',
+      content
+    }).should.eql(`<meta property="og:url" content="${encoded}">`);
+
+    htmlTag('meta', {
+      property: 'og:image:secure_url',
+      content
+    }).should.eql(`<meta property="og:image:secure_url" content="${encoded}">`);
+
+    htmlTag('meta', {
+      name: 'twitter:image',
+      content
+    }).should.eql(`<meta name="twitter:image" content="${encoded}">`);
+
+    htmlTag('meta', {
+      name: 'foo image',
+      content: 'bar " baz'
+    }).should.eql('<meta name="foo image" content="bar &quot; baz">');
   });
 });


### PR DESCRIPTION
While working on https://github.com/hexojs/hexo/pull/3983, I found url in open graph or twitter card tag is html-escaped instead of url-encoded.