### PR TITLE
fix(tocObj): avoid checking length of null

### DIFF
--- a/lib/toc_obj.js
+++ b/lib/toc_obj.js
@@ -11,7 +11,7 @@ const parseHtml = html => {
 const getId = ele => {
   const { id } = ele.attribs;
   const { parent } = ele;
-  return id || (parent.length < 1 ? null : getId(parent));
+  return id || (!parent ? null : getId(parent));
 };
 
 function tocObj(str, options = {}) {

--- a/test/toc_obj.spec.js
+++ b/test/toc_obj.spec.js
@@ -72,6 +72,15 @@ describe('tocObj', () => {
     checkNull.should.eql(true);
   });
 
+  it('empty value in id attribute', () => {
+    const noid = '<h1 id="">Title 1</h1>';
+    const result = tocObj(noid);
+    const checkNull = result[0].id === null;
+
+    result.length.should.eql(1);
+    checkNull.should.eql(true);
+  });
+
   it('invalid input', () => {
     const foo = 'barbaz';
     const result = tocObj(foo);

--- a/test/toc_obj.spec.js
+++ b/test/toc_obj.spec.js
@@ -62,4 +62,20 @@ describe('tocObj', () => {
 
     tocObj(html, { max_depth: 2 }).should.eql(expected);
   });
+
+  it('no id attribute', () => {
+    const noid = '<h1>Title 1</h1>';
+    const result = tocObj(noid);
+    const checkNull = result[0].id === null;
+
+    result.length.should.eql(1);
+    checkNull.should.eql(true);
+  });
+
+  it('invalid input', () => {
+    const foo = 'barbaz';
+    const result = tocObj(foo);
+
+    result.length.should.eql(0);
+  });
 });


### PR DESCRIPTION
tocObj currently crashes hexo if the heading doesn't have `id` attribute, e.g. `<h1>Title 1</h1>`. This PR makes it more robust.

With this PR, in relation to the [`toc()`](https://github.com/hexojs/hexo/blob/f50821c596a9c3a53619cbb846509e6071a1780d/lib/plugins/helper/toc.js#L50) helper, it would output

```
<a class="header-link" href="#null">
```

obviously anchor link wouldn't work, but at least there is a toc.