### PR TITLE
refactor(highlight): add strip-indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,10 @@ spawn('cat', 'test.txt').then(function(content){
 
 Removes HTML tags in a string.
 
+### stripIndent(str)
+
+Strip leading whitespace from each line in a string. The line with the least number of leading whitespace, ignoring empty lines, determines the number to remove. Useful for removing redundant indentation.
+
 ### wordWrap(str, [options])
 
 Wraps the string no longer than line width. This method breaks on the first whitespace character that does not exceed line width.

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -1,11 +1,13 @@
 'use strict';
 
 const hljs = require('highlight.js');
+const stripIndent = require('strip-indent');
 const alias = require('../highlight_alias.json');
 const escapeHTML = require('./escape_html');
 
 function highlightUtil(str, options = {}) {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
+  str = stripIndent(str);
 
   const useHljs = Object.prototype.hasOwnProperty.call(options, 'hljs') ? options.hljs : false;
   const {
@@ -73,10 +75,6 @@ function formatLine(line, lineno, marked, options) {
   return res;
 }
 
-function encodePlainString(str) {
-  return escapeHTML(str);
-}
-
 function replaceTabs(str, tab) {
   return str.replace(/^\t+/, match => {
     let result = '';
@@ -103,7 +101,7 @@ function highlight(str, options) {
   }
 
   const result = {
-    value: encodePlainString(str),
+    value: escapeHTML(str),
     language: lang.toLowerCase()
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ exports.relative_url = require('./relative_url');
 exports.slugize = require('./slugize');
 exports.spawn = require('./spawn');
 exports.stripHTML = require('./strip_html');
+exports.stripIndent = require('./strip_indent');
 exports.tocObj = require('./toc_obj');
 exports.truncate = require('./truncate');
 exports.unescapeHTML = require('./unescape_html');

--- a/lib/strip_indent.js
+++ b/lib/strip_indent.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('strip-indent');

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "highlight.js": "^9.13.1",
     "htmlparser2": "^4.0.0",
     "punycode.js": "^2.1.0",
+    "strip-indent": "^3.0.0",
     "striptags": "^3.1.1"
   },
   "engines": {


### PR DESCRIPTION
During writing proposal at https://github.com/hexojs/hexo/issues/4010, I noticed `strip-indent` is used at `hexo-renderer-marked` and [`backtick_code` filter](https://github.com/hexojs/hexo/blob/master/lib/plugins/filter/before_post_render/backtick_code_block.js).

Although `strip-indent` at `hexo-renderer-marked` will be removed in https://github.com/hexojs/hexo-renderer-marked/pull/134, but after [searching `strip-indent` at `hexojs/hexo`](https://github.com/hexojs/hexo/search?q=strip-indent&unscoped_q=strip-indent) I found `strip-indent` mostly used for highlight in `hexojs/hexo` as well. It means we should add `strip-indent` inside `highlightUtils`.

After this PR is merged, `strip-indent` inside `hexojs/hexo` could be removed.
