### PR TITLE
Fix highlighting when hljs=true

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -116,8 +116,6 @@ function highlight(str, options) {
     return result;
   }
 
-  if (options.hljs) return hljs.highlight(lang, str);
-
   return tryHighlight(str, result.language) || result;
 }
 


### PR DESCRIPTION
I found that the highlighting is incorrect when options.hljs=true.

It should use the `tryHighlight` function instead, which handles multi-line codeblock.