### PR TITLE
fix(tocObj): skip permalink symbol 

### DIFF
--- a/lib/toc_obj.js
+++ b/lib/toc_obj.js
@@ -1,6 +1,7 @@
 'use strict';
 const { DomHandler, DomUtils, Parser } = require('htmlparser2');
 const escapeHTML = require('./escape_html');
+const nonWord = /^\s*[^a-zA-Z0-9]\s*$/;
 
 const parseHtml = html => {
   const handler = new DomHandler(null, {});
@@ -30,7 +31,16 @@ function tocObj(str, options = {}) {
     const el = headings[i];
     const level = +el.name[1];
     const id = getId(el);
-    const text = escapeHTML(DomUtils.getText(el));
+    let text = '';
+    for (const element of el.children) {
+      const elText = DomUtils.getText(element);
+      // Skip permalink symbol
+      // permalink is a single non-word character, word = [a-Z0-9]
+      // permalink may be wrapped in whitespace(s)
+      if (element.name !== 'a' || !nonWord.test(elText)) {
+        text += escapeHTML(elText);
+      }
+    }
 
     result.push({ text, id, level });
   }

--- a/lib/toc_obj.js
+++ b/lib/toc_obj.js
@@ -34,13 +34,14 @@ function tocObj(str, options = {}) {
     let text = '';
     for (const element of el.children) {
       const elText = DomUtils.getText(element);
-      // Skip permalink symbol
+      // Skip permalink symbol wrapped in <a>
       // permalink is a single non-word character, word = [a-Z0-9]
       // permalink may be wrapped in whitespace(s)
       if (element.name !== 'a' || !nonWord.test(elText)) {
         text += escapeHTML(elText);
       }
     }
+    if (!text) text = escapeHTML(DomUtils.getText(el));
 
     result.push({ text, id, level });
   }

--- a/lib/toc_obj.js
+++ b/lib/toc_obj.js
@@ -10,7 +10,7 @@ const parseHtml = html => {
 };
 
 const getId = ({ attribs, parent }) => {
-  return attribs.id || (!parent ? null : getId(parent));
+  return attribs.id || (!parent ? '' : getId(parent));
 };
 
 function tocObj(str, options = {}) {

--- a/test/toc_obj.spec.js
+++ b/test/toc_obj.spec.js
@@ -87,4 +87,73 @@ describe('tocObj', () => {
 
     result.length.should.eql(0);
   });
+
+  it('empty text', () => {
+    const input = '<h1></h1>';
+    const result = tocObj(input);
+
+    result[0].text.should.eql('');
+  });
+
+  describe('children element', () => {
+    it('<a> element with permalink + text', () => {
+      const input = [
+        '<h1><a>#</a>foo</h1>',
+        '<h1>foo<a>#</a></h1>',
+        '<h1><a>#</a>foo<a>#</a></h1>',
+        '<h1><a># </a>foo</h1>',
+        '<h1><a># </a>foo<a> #</a></h1>',
+        '<h1><a>号</a>foo</h1>'
+      ];
+      const result = input.map(str => tocObj(str));
+
+      result.forEach(str => str[0].text.should.eql('foo'));
+    });
+
+    it('<a> element - no text', () => {
+      const input = '<h1><a>foo</a></h1>';
+      const result = tocObj(input);
+
+      result[0].text.should.eql('foo');
+    });
+
+    it('non-permalink <a> element + text', () => {
+      const input = [
+        '<h1><a>foo</a>bar</h1>',
+        '<h1>foo<a>bar</a></h1>'
+      ];
+      const result = input.map(str => tocObj(str));
+
+      result.forEach(str => str[0].text.should.eql('foobar'));
+    });
+
+    it('non-permalink <a> element + unicode text', () => {
+      const input = [
+        '<h1><a>这是</a>测试</h1>',
+        '<h1>这是<a>测试</a></h1>'
+      ];
+      const result = input.map(str => tocObj(str));
+
+      result.forEach(str => str[0].text.should.eql('这是测试'));
+    });
+
+    it('multiple <a> elements', () => {
+      const input = '<h1><a>foo</a><a>bar</a></h1>';
+      const result = tocObj(input);
+
+      result[0].text.should.eql('foobar');
+    });
+
+    it('element + text', () => {
+      const input = [
+        '<h1><i>foo</i>barbaz</h1>',
+        '<h1><i>foo</i>bar</i>baz</h1>',
+        '<h1>foo<i>bar</i>baz</h1>',
+        '<h1>foobarba<i>z</i></h1>'
+      ];
+      const result = input.map(str => tocObj(str));
+
+      result.forEach(str => str[0].text.should.eql('foobarbaz'));
+    });
+  });
 });

--- a/test/toc_obj.spec.js
+++ b/test/toc_obj.spec.js
@@ -66,19 +66,15 @@ describe('tocObj', () => {
   it('no id attribute', () => {
     const noid = '<h1>Title 1</h1>';
     const result = tocObj(noid);
-    const checkNull = result[0].id === null;
 
-    result.length.should.eql(1);
-    checkNull.should.eql(true);
+    result[0].id.should.eql('');
   });
 
   it('empty value in id attribute', () => {
     const noid = '<h1 id="">Title 1</h1>';
     const result = tocObj(noid);
-    const checkNull = result[0].id === null;
 
-    result.length.should.eql(1);
-    checkNull.should.eql(true);
+    result[0].id.should.eql('');
   });
 
   it('invalid input', () => {

--- a/test/toc_obj.spec.js
+++ b/test/toc_obj.spec.js
@@ -113,6 +113,20 @@ describe('tocObj', () => {
       result[0].text.should.eql('foo');
     });
 
+    it('<a> element - single permalink', () => {
+      const input = '<h1><a>#</a></h1>';
+      const result = tocObj(input);
+
+      result[0].text.should.eql('#');
+    });
+
+    it('<a> element - non-permalink', () => {
+      const input = '<h1><a>a</a> one</h1>';
+      const result = tocObj(input);
+
+      result[0].text.should.eql('a one');
+    });
+
     it('non-permalink <a> element + text', () => {
       const input = [
         '<h1><a>foo</a>bar</h1>',


### PR DESCRIPTION
Fixes https://github.com/hexojs/hexo-util/issues/174 Closes https://github.com/hexojs/hexo-renderer-markdown-it/issues/102

Permalink (in this context) is a single non-word character, word = [a-Z0-9], and wrapped in `<a>`.
It may be wrapped in whitespace(s)

Scenario | Input | Output (text) | Explanation
--- | --- | --- | ---
1 | `<h1 id="foo"><a>#</a>bar</h1>`<br><br>`<h1 id="foo">bar<a>#</a></h1>`<br><br>`<h1 id="foo"><a>#</a>bar<a>#</a></h1>` | `bar`<br><br>`bar`<br><br>`bar` | `#` is treated as a permalink and skipped
2 | `<h1>号码<a>牌</a></h1>` | `号码` | `牌` is treated as a permalink
3 | `<h1><a>#</a></h1>` | `#` | If there is only permalink, parse it
4 | `<h1><a>b</a> two</h1>` | `b two` | `b` is not a permalink

---

returns empty string `''` instead of null. This is following convention. htmlparser2 `DomUtils.getText(elNoText)` and [camaro](https://www.npmjs.com/package/camaro) `camaro.transform(xml, {foo:'invalid'})` also return empty string. This is [compatible](https://github.com/hexojs/hexo/blob/79bb3aab3bef68d55798a2fe2eed2496dc8562dc/lib/plugins/helper/toc.js#L28) with toc, as empty string is still falsy (same as null and undefined).