### PR TITLE
htmlTag - toString() before match() for scalar values.

### DIFF
--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -25,7 +25,7 @@ function htmlTag(tag, attrs, text, escape = true) {
     if (attrs[i] == null) result += '';
     else {
       if (i.match(regexUrl)
-        || (tag === 'meta' && !attrs[i].toString().match(regexMeta) && Object.values(attrs)[0].match(regexMeta))) {
+        || (tag === 'meta' && String(!attrs[i]).match(regexMeta) && Object.values(attrs)[0].match(regexMeta))) {
         result += ` ${escapeHTML(i)}="${encodeURL(attrs[i])}"`;
       } else if (attrs[i] === true || i === attrs[i]) result += ` ${escapeHTML(i)}`;
       else if (i.match(/srcset$/i)) result += ` ${escapeHTML(i)}="${encSrcset(attrs[i])}"`;

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -25,7 +25,7 @@ function htmlTag(tag, attrs, text, escape = true) {
     if (attrs[i] == null) result += '';
     else {
       if (i.match(regexUrl)
-        || (tag === 'meta' && !attrs[i].match(regexMeta) && Object.values(attrs)[0].match(regexMeta))) {
+        || (tag === 'meta' && !attrs[i].toString().match(regexMeta) && Object.values(attrs)[0].match(regexMeta))) {
         result += ` ${escapeHTML(i)}="${encodeURL(attrs[i])}"`;
       } else if (attrs[i] === true || i === attrs[i]) result += ` ${escapeHTML(i)}`;
       else if (i.match(/srcset$/i)) result += ` ${escapeHTML(i)}="${encSrcset(attrs[i])}"`;

--- a/lib/html_tag.js
+++ b/lib/html_tag.js
@@ -25,7 +25,7 @@ function htmlTag(tag, attrs, text, escape = true) {
     if (attrs[i] == null) result += '';
     else {
       if (i.match(regexUrl)
-        || (tag === 'meta' && String(!attrs[i]).match(regexMeta) && Object.values(attrs)[0].match(regexMeta))) {
+        || (tag === 'meta' && !String(attrs[i]).match(regexMeta) && Object.values(attrs)[0].match(regexMeta))) {
         result += ` ${escapeHTML(i)}="${encodeURL(attrs[i])}"`;
       } else if (attrs[i] === true || i === attrs[i]) result += ` ${escapeHTML(i)}`;
       else if (i.match(/srcset$/i)) result += ` ${escapeHTML(i)}="${encSrcset(attrs[i])}"`;

--- a/test/html_tag.spec.js
+++ b/test/html_tag.spec.js
@@ -151,4 +151,11 @@ describe('htmlTag', () => {
       content: 'bar " baz'
     }).should.eql('<meta name="foo image" content="bar &quot; baz">');
   });
+
+  it('meta tag - numeric property', () => {
+    htmlTag('meta', {
+      property: 'fb:app_id',
+      content: 123456789
+    }).should.eql('<meta property="fb:app_id" content="123456789">');
+  });
 });


### PR DESCRIPTION
Fixed crash when entering a numerical value into `fb_app_id` of` open_graph` helper.

Facebook app_id is a numeric string, but if it is set in `_config.yml` without quotes, the yml parser will recognize it as number.

1.8.0 and later versions crashed if the value was set to number.