### PR TITLE
perf(escapeHTML): use multiple replace

### DIFF
--- a/lib/escape_html.js
+++ b/lib/escape_html.js
@@ -2,7 +2,7 @@
 
 const unescapeHTML = require('./unescape_html');
 
-const htmlEntityMap = {
+/* const htmlEntityMap = {
   '&': '&amp;',
   '<': '&lt;',
   '>': '&gt;',
@@ -11,7 +11,7 @@ const htmlEntityMap = {
   '`': '&#96;',
   '/': '&#x2F;',
   '=': '&#x3D;'
-};
+}; */
 
 function escapeHTML(str) {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
@@ -19,7 +19,19 @@ function escapeHTML(str) {
   str = unescapeHTML(str);
 
   // http://stackoverflow.com/a/12034334
-  return str.replace(/[&<>"'`/=]/g, a => htmlEntityMap[a]);
+  // return str.replace(/[&<>"'`/=]/g, a => htmlEntityMap[a]);
+
+  // Multiple replacement is faster than map replacement on Node.js 12 or later.
+  // Benchmark: https://runkit.com/sukkaw/5e3003ffe7e84c0013f6210d
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;')
+    .replace(/\//g, '&#x2F;')
+    .replace(/=/g, '&#x3D;');
 }
 
 module.exports = escapeHTML;

--- a/lib/unescape_html.js
+++ b/lib/unescape_html.js
@@ -1,22 +1,17 @@
 'use strict';
 
-const htmlEntityMap = {
-  '&amp;': '&',
-  '&lt;': '<',
-  '&gt;': '>',
-  '&quot;': '"',
-  '&#39;': '\'',
-  '&#96;': '`',
-  '&#x2F;': '/',
-  '&#x3D;': '='
-};
-
-const regexHtml = new RegExp(Object.keys(htmlEntityMap).join('|'), 'g');
-
 const unescapeHTML = str => {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
 
-  return str.replace(regexHtml, a => htmlEntityMap[a]);
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, '\'')
+    .replace(/&#96;/g, '`')
+    .replace(/&#x2F;/g, '/')
+    .replace(/&#x3D;/g, '=');
 };
 
 module.exports = unescapeHTML;


### PR DESCRIPTION
Benchmark: https://runkit.com/sukkaw/5e3003ffe7e84c0013f6210d

```js
const Benchmark = require('benchmark');
const Suite = new Benchmark.Suite;
const html = `<p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p><p class="foo">Hello "world".</p>`;
const htmlEntityMap = {
  '&': '&amp;',
  '<': '&lt;',
  '>': '&gt;',
  '"': '&quot;',
  '\'': '&#39;',
  '`': '&#96;',
  '/': '&#x2F;',
  '=': '&#x3D;'
};

Suite.add('Map replacement', () => {
  html.replace(/[&<>"'`/=]/g, a => htmlEntityMap[a]);
}).add('Multiple replace', () => {
  html.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/\\/g, '&#39;').replace(/`/g, '&#96;').replace(/\//g, '&#x2F').replace(/=/g, '&#x3D');
}).on('cycle', function(event) {
  console.info(String(event.target));
}).run();
```

On my local computer, `Multiple replace` is the slower one under Node.js 10 but it is the faster one under Node.js 12 & 13:

![image](https://user-images.githubusercontent.com/40715044/73255537-46e17980-41fb-11ea-8bcd-597c2bae4173.png)
