### PR TITLE
fix(is_external_link): handle invalid url

### DIFF
--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -16,8 +16,7 @@ function fullUrlForHelper(path = '/') {
 
   // cacheId is designed to works across different hexo.config & options
   return cache.apply(`${config.url}-${prettyUrlsOptions.trailing_index}-${prettyUrlsOptions.trailing_html}-${path}`, () => {
-    const pathRegex = /^(\/\/|http(s)?:)/;
-    if (pathRegex.test(path)) return path;
+    if (/^(\/\/|http(s)?:)/.test(path)) return path;
 
     const sitehost = parse(config.url).hostname || config.url;
     const data = new URL(path, `http://${sitehost}`);

--- a/lib/is_external_link.js
+++ b/lib/is_external_link.js
@@ -13,6 +13,9 @@ const cache = new Cache();
 
 function isExternalLink(input, sitehost, exclude) {
   return cache.apply(`${input}-${sitehost}-${exclude}`, () => {
+    // Return false early for internal link
+    if (!/^(\/\/|http(s)?:)/.test(input)) return false;
+
     sitehost = parse(sitehost).hostname || sitehost;
 
     if (!sitehost) return false;

--- a/lib/is_external_link.js
+++ b/lib/is_external_link.js
@@ -16,8 +16,15 @@ function isExternalLink(input, sitehost, exclude) {
     sitehost = parse(sitehost).hostname || sitehost;
 
     if (!sitehost) return false;
-    // handle relative url
-    const data = new URL(input, `http://${sitehost}`);
+
+    // handle relative url and invalid url
+    let data;
+    try {
+      data = new URL(input, `http://${sitehost}`);
+    } catch (e) { }
+
+    // if input is invalid url, data should be undefined
+    if (typeof data !== 'object') return false;
 
     // handle mailto: javascript: vbscript: and so on
     if (data.origin === 'null') return false;

--- a/lib/url_for.js
+++ b/lib/url_for.js
@@ -28,10 +28,7 @@ function urlForHelper(path = '/', options) {
 
   // cacheId is designed to works across different hexo.config & options
   return cache.apply(`${config.url}-${root}-${prettyUrlsOptions.trailing_index}-${prettyUrlsOptions.trailing_html}-${path}`, () => {
-    const pathRegex = /^(#|\/\/|http(s)?:)/;
-    if (pathRegex.test(path)) {
-      return path;
-    }
+    if (/^(#|\/\/|http(s)?:)/.test(path)) return path;
 
     const sitehost = parse(config.url).hostname || config.url;
     const data = new URL(path, `http://${sitehost}`);

--- a/test/is_external_link.spec.js
+++ b/test/is_external_link.spec.js
@@ -9,6 +9,10 @@ describe('isExternalLink', () => {
 
   const isExternalLink = require('../lib/is_external_link');
 
+  it('invalid url', () => {
+    isExternalLink('https://localhost:4000你好', ctx.config.url).should.eql(false);
+  });
+
   it('external link', () => {
     isExternalLink('https://hexo.io/', ctx.config.url).should.eql(true);
   });

--- a/test/is_external_link.spec.js
+++ b/test/is_external_link.spec.js
@@ -15,6 +15,7 @@ describe('isExternalLink', () => {
 
   it('external link', () => {
     isExternalLink('https://hexo.io/', ctx.config.url).should.eql(true);
+    isExternalLink('//hexo.io/', ctx.config.url).should.eql(true);
   });
 
   it('internal link', () => {
@@ -22,6 +23,7 @@ describe('isExternalLink', () => {
     isExternalLink('//example.com', ctx.config.url).should.eql(false);
     isExternalLink('//example.com/archives/foo.html', ctx.config.url).should.eql(false);
     isExternalLink('/archives/foo.html', ctx.config.url).should.eql(false);
+    isExternalLink('/archives//hexo.io', ctx.config.url).should.eql(false);
   });
 
   it('hash, mailto, javascript', () => {


### PR DESCRIPTION
Details can be found at https://github.com/hexojs/hexo/issues/4130

This PR introduce a try block and treat invalid URL as internal link (return `false`).