### PR TITLE
fix(prism): add strip_indent support

### DIFF
--- a/lib/prism.js
+++ b/lib/prism.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Prism = require('prismjs');
+const stripIndent = require('strip-indent');
 const prismLoadLanguages = require('prismjs/components/');
 
 // https://github.com/PrismJS/prism/issues/2145
@@ -53,6 +54,7 @@ function replaceTabs(str, tab) {
 
 function PrismUtil(str, options = {}) {
   if (typeof str !== 'string') throw new TypeError('str must be a string!');
+  str = stripIndent(str);
 
   const {
     lineNumber = true,

--- a/test/prism.spec.js
+++ b/test/prism.spec.js
@@ -2,6 +2,7 @@
 
 require('chai').should();
 const escapeHTML = require('../lib/escape_html');
+const stripIndent = require('strip-indent');
 
 const validator = require('html-tag-validator');
 function validateHtmlAsync(str, done) {
@@ -44,7 +45,7 @@ describe('prismHighlight', () => {
     // Line Number
     result.should.contains(lineNumberStartTag);
     // Code should only be escaped.
-    result.should.contains(escapeHTML(input));
+    result.should.contains(escapeHTML(stripIndent(input)));
     result.should.not.contains(highlightToken);
 
     validateHtmlAsync(result, done);
@@ -175,7 +176,7 @@ describe('prismHighlight', () => {
     // Line Number
     result.should.contains(lineNumberStartTag);
     // Code should only be escaped.
-    result.should.contains(escapeHTML(input));
+    result.should.contains(escapeHTML(stripIndent(input)));
     result.should.not.contains(highlightToken);
 
     validateHtmlAsync(result, done);


### PR DESCRIPTION
Adding `stripIndent()` for prism highlight as well as highlightjs:

https://github.com/hexojs/hexo-util/blob/7e5633a229202c3c4fc130bf61784af0d5ad44ef/lib/highlight.js#L10