### PR TITLE
* fix config.url startswith slash

### DIFF
--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -18,7 +18,8 @@ function fullUrlForHelper(path = '/') {
   return cache.apply(`${config.url}-${prettyUrlsOptions.trailing_index}-${prettyUrlsOptions.trailing_html}-${path}`, () => {
     if (/^(\/\/|http(s)?:)/.test(path)) return path;
 
-    const sitehost = parse(config.url).hostname || config.url;
+    const config_url = config.url.startsWith('//') ? `https:${config.url}` : config.url;
+    const sitehost = parse(config_url).hostname || config_url;
     const data = new URL(path, `http://${sitehost}`);
 
     // Exit if input is an external link or a data url

--- a/lib/url_for.js
+++ b/lib/url_for.js
@@ -30,7 +30,8 @@ function urlForHelper(path = '/', options) {
   return cache.apply(`${config.url}-${root}-${prettyUrlsOptions.trailing_index}-${prettyUrlsOptions.trailing_html}-${path}`, () => {
     if (/^(#|\/\/|http(s)?:)/.test(path)) return path;
 
-    const sitehost = parse(config.url).hostname || config.url;
+    const config_url = config.url.startsWith('//') ? `https:${config.url}` : config.url;
+    const sitehost = parse(config_url).hostname || config_url;
     const data = new URL(path, `http://${sitehost}`);
 
     // Exit if input is an external link or a data url


### PR DESCRIPTION
If I use '//blog.umu618.com' as config.url, the url_for is malfunctioned.