### PR TITLE
ci(travis): drop Node 8 and add Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ cache:
   npm: true
 
 node_js:
-  - "8"
   - "10"
   - "12"
   - "13"
+  - "14"
 
 script:
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then


### PR DESCRIPTION
smaller scope than https://github.com/hexojs/hexo-util/pull/191, affects travis only.

mainly to debug https://github.com/hexojs/hexo/issues/4260.