### PR TITLE
fix: avoid overriding Transform.destroy() method

### DIFF
--- a/lib/cache_stream.js
+++ b/lib/cache_stream.js
@@ -18,10 +18,6 @@ CacheStream.prototype._transform = function(chunk, enc, callback) {
   callback();
 };
 
-CacheStream.prototype.destroy = function() {
-  this._cache.length = 0;
-};
-
 CacheStream.prototype.getCache = function() {
   return Buffer.concat(this._cache);
 };

--- a/test/cache_stream.spec.js
+++ b/test/cache_stream.spec.js
@@ -20,12 +20,4 @@ describe('CacheStream', () => {
       cacheStream.getCache().should.eql(content);
     });
   });
-
-  it('destroy', () => {
-    const cacheStream = new CacheStream();
-    cacheStream._cache = [Buffer.alloc(1)];
-
-    cacheStream.destroy();
-    cacheStream._cache.should.have.length(0);
-  });
 });


### PR DESCRIPTION
fix compatibility with Node 14

https://github.com/hexojs/hexo/issues/4260#issuecomment-618483486