### PR TITLE
docs(highlight): 'sublanguage highlight' requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Option | Description | Default
 `lang` | Language |
 `caption` | Caption |
 `tab`| Replace tabs |
-`autoDetect` | Detect language automatically | false
+`autoDetect` | Detect language automatically<br>_Sublanguage highlight requires `autoDetect` to be enabled and `lang` to be unset_  | false
 `mark` | Line highlight specific line(s) |
 
 ### htmlTag(tag, attrs, text, escape)

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Option | Description | Default
 `lang` | Language |
 `caption` | Caption |
 `tab`| Replace tabs |
-`autoDetect` | Detect language automatically<br>_Sublanguage highlight requires `autoDetect` to be enabled and `lang` to be unset_  | false
+`autoDetect` | Detect language automatically (warning: slow)<br>_Sublanguage highlight requires `autoDetect` to be enabled and `lang` to be unset_  | false
 `mark` | Line highlight specific line(s) |
 
 ### htmlTag(tag, attrs, text, escape)


### PR DESCRIPTION
breaking change introduced by highlight.js v10 https://github.com/hexojs/hexo-util/pull/192.