### PR TITLE
feat(hash): drop HashStream()

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,21 +259,6 @@ hash('123456');
 // <Buffer 7c 4a 8d 09 ca 37 62 af 61 e5 95 20 94 3d c2 64 94 f8 94 1b>
 ```
 
-### HashStream()
-**\[deprecated\]** use [`createSha1Hash()`](#createsha1hash).
-
-Generates SHA1 hash with a transform stream.
-
-``` js
-var stream = new HashStream();
-
-fs.createReadStream('/path/to/file')
-  .pipe(stream)
-  .on('finish', function(){
-    console.log(stream.read());
-  });
-```
-
 ### highlight(str, [options])
 
 Syntax highlighting for a code block.

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { Transform } = require('stream');
 const crypto = require('crypto');
 
 const ALGORITHM = 'sha1';
@@ -9,32 +8,10 @@ function createSha1Hash() {
   return crypto.createHash(ALGORITHM);
 }
 
-/**
- * @deprecated
- * createHash() is stream class.
- */
-function HashStream() {
-  Transform.call(this);
-  this._hash = createSha1Hash();
-}
-
-require('util').inherits(HashStream, Transform);
-
-HashStream.prototype._transform = function(chunk, enc, callback) {
-  this._hash.update(chunk);
-  callback();
-};
-
-HashStream.prototype._flush = function(callback) {
-  this.push(this._hash.digest());
-  callback();
-};
-
 exports.hash = content => {
   const hash = createSha1Hash();
   hash.update(content);
   return hash.digest();
 };
 
-exports.HashStream = HashStream;
 exports.createSha1Hash = createSha1Hash;

--- a/test/hash.spec.js
+++ b/test/hash.spec.js
@@ -18,16 +18,6 @@ describe('hash', () => {
     hash.hash(content).should.eql(sha1(content));
   });
 
-  it('HashStream', () => {
-    const content = '123456';
-    const stream = new hash.HashStream();
-
-    stream.write(Buffer.from(content));
-    stream.end();
-
-    stream.read().should.eql(sha1(content));
-  });
-
   it('createSha1Hash', () => {
     const _sha1 = hash.createSha1Hash();
     const content = '123456';


### PR DESCRIPTION
this finally drops `HashStream()` which has been long deprecated since https://github.com/hexojs/hexo-util/pull/45.