### PR TITLE
fix: avoid overriding Transform.destroy() method

### DIFF
--- a/lib/cache_stream.js
+++ b/lib/cache_stream.js
@@ -18,10 +18,6 @@ CacheStream.prototype._transform = function(chunk, enc, callback) {
   callback();
 };
 
-CacheStream.prototype.destroy = function() {
-  this._cache.length = 0;
-};
-
 CacheStream.prototype.getCache = function() {
   return Buffer.concat(this._cache);
 };

--- a/test/cache_stream.spec.js
+++ b/test/cache_stream.spec.js
@@ -20,12 +20,4 @@ describe('CacheStream', () => {
       cacheStream.getCache().should.eql(content);
     });
   });
-
-  it('destroy', () => {
-    const cacheStream = new CacheStream();
-    cacheStream._cache = [Buffer.alloc(1)];
-
-    cacheStream.destroy();
-    cacheStream._cache.should.have.length(0);
-  });
 });


### PR DESCRIPTION
backport of #195 

This PR for hexo v4.2.1
> https://github.com/hexojs/hexo/pull/4285

Target branch is `1.9.1`

Only this commit is different from v1.9.0
I will release v1.9.1 after merge this PR.