### PR TITLE
Reverts hexojs/hexo-util#204

### DIFF
--- a/lib/full_url_for.js
+++ b/lib/full_url_for.js
@@ -18,17 +18,13 @@ function fullUrlForHelper(path = '/') {
   return cache.apply(`${config.url}-${prettyUrlsOptions.trailing_index}-${prettyUrlsOptions.trailing_html}-${path}`, () => {
     if (/^(\/\/|http(s)?:)/.test(path)) return path;
 
-    const config_url = config.url ? config.url : '';
+    const sitehost = parse(config.url).hostname || config.url;
+    const data = new URL(path, `http://${sitehost}`);
 
-    // if sitehost is empty, skip this step
-    if (config_url !== '' && config_url !== null) {
-      const sitehost = parse(config_url).hostname || config.url;
-      const data = new URL(path, `http://${sitehost}`);
-      // Exit if input is an external link or a data url
-      if (data.hostname !== sitehost || data.origin === 'null') return path;
-    }
+    // Exit if input is an external link or a data url
+    if (data.hostname !== sitehost || data.origin === 'null') return path;
 
-    path = encodeURL(config_url + `/${path}`.replace(/\/{2,}/g, '/'));
+    path = encodeURL(config.url + `/${path}`.replace(/\/{2,}/g, '/'));
     path = prettyUrls(path, prettyUrlsOptions);
 
     return path;

--- a/test/full_url_for.spec.js
+++ b/test/full_url_for.spec.js
@@ -88,28 +88,4 @@ describe('full_url_for', () => {
       fullUrlFor(url).should.eql(url);
     });
   });
-
-  it('config url is empty', () => {
-    ctx.config.url = '';
-    fullUrlFor('test/').should.eql('/test/');
-    fullUrlFor('https://hexo.io/').should.eql('https://hexo.io/');
-    fullUrlFor('/foo/bar.html').should.eql('/foo/bar');
-    fullUrlFor('#test').should.eql('/#test');
-  });
-
-  it('config url is null', () => {
-    ctx.config.url = null;
-    fullUrlFor('test/').should.eql('/test/');
-    fullUrlFor('https://hexo.io/').should.eql('https://hexo.io/');
-    fullUrlFor('/foo/bar.html').should.eql('/foo/bar');
-    fullUrlFor('#test').should.eql('/#test');
-  });
-
-  it('config url is undefined', () => {
-    delete ctx.config.url;
-    fullUrlFor('test/').should.eql('/test/');
-    fullUrlFor('https://hexo.io/').should.eql('https://hexo.io/');
-    fullUrlFor('/foo/bar.html').should.eql('/foo/bar');
-    fullUrlFor('#test').should.eql('/#test');
-  });
 });


### PR DESCRIPTION
Merged caused by mistake.

`config.url` should always be configured. Throwing error is desired behavior and must be retained.