### PR TITLE
feat/refactor(cache): use Map, cache#dump, cache#size

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ cache.apply('qux', 456);
 cache.apply('qux', '789');
 // 456
 
+// size()
+cache.size();
+// 3
+
+// dump()
+cache.dump();
+/*
+{
+  foo: 'bar',
+  baz: 123,
+  qux: 456
+}
+*/
+
 // del(key)
 cache.del('baz');
 cache.has('baz');
@@ -94,6 +108,8 @@ cache.has('baz');
 cache.flush();
 cache.has('foo');
 // false
+cache.size();
+// 0
 ```
 
 ### CacheStream()

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -2,23 +2,23 @@
 
 module.exports = class Cache {
   constructor() {
-    this.cache = {};
+    this.cache = new Map();
   }
 
   set(id, value) {
-    this.cache[id] = value;
+    this.cache.set(id, value);
   }
 
   has(id) {
-    return typeof this.cache[id] !== 'undefined';
+    return this.cache.has(id);
   }
 
   get(id) {
-    return this.cache[id];
+    return this.cache.get(id);
   }
 
   del(id) {
-    delete this.cache[id];
+    this.cache.delete(id);
   }
 
   apply(id, value) {
@@ -31,6 +31,27 @@ module.exports = class Cache {
   }
 
   flush() {
-    this.cache = {};
+    this.cache.clear();
+  }
+
+  size() {
+    return this.cache.size;
+  }
+
+  dump() {
+    // Object#fromEntries supported since Node.js 12
+
+    // eslint-disable-next-line node/no-unsupported-features/es-builtins
+    if (typeof Object.fromEntries === 'function') {
+      // eslint-disable-next-line node/no-unsupported-features/es-builtins
+      return Object.fromEntries(this.cache);
+    }
+
+    // FIXME: A polyfill for Node.js 10 & 11
+    const obj = {};
+    this.cache.forEach((v, k) => {
+      obj[k] = v;
+    });
+    return obj;
   }
 };

--- a/test/cache.spec.js
+++ b/test/cache.spec.js
@@ -11,6 +11,11 @@ describe('Cache', () => {
     cache.get('foo').should.eql(123);
   });
 
+  it('size', () => {
+    cache.set('foobar', 456);
+    cache.size().should.eql(2);
+  });
+
   it('has', () => {
     cache.has('foo').should.eql(true);
     cache.has('bar').should.eql(false);
@@ -28,6 +33,15 @@ describe('Cache', () => {
     cache.apply('baz', () => 456).should.eql(123);
   });
 
+  it('dump', () => {
+    cache.dump().should.eql({
+      'bar': 123,
+      'baz': 123,
+      'foo': 123,
+      'foobar': 456
+    });
+  });
+
   it('del', () => {
     cache.del('baz');
     cache.has('foo').should.eql(true);
@@ -39,6 +53,7 @@ describe('Cache', () => {
     cache.has('foo').should.eql(false);
     cache.has('bar').should.eql(false);
     cache.has('baz').should.eql(false);
+    cache.size().should.eql(0);
   });
 
   it('cache null', () => {


### PR DESCRIPTION
> (Map) Performs better in scenarios involving frequent additions and removals of key-value pairs. (While Object is) Not optimized for frequent additions and removals of key-value pairs.
>
> Objects vs. Maps, [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)

`cache#dump` & `cache#size` is also implemented.