### PR TITLE
feat(highlight): support caption when wrap is disabled

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -30,7 +30,9 @@ function highlightUtil(str, options = {}) {
   const before = useHljs ? `<pre><code class="${classNames}">` : '<pre>';
   const after = useHljs ? '</code></pre>' : '</pre>';
 
-  if (!wrap) return `<pre><code class="${classNames}">${data.value}</code></pre>`;
+  const figCaption = caption ? `<figcaption>${caption}</figcaption>` : '';
+
+  if (!wrap) return `<pre>${figCaption}<code class="${classNames}">${data.value}</code></pre>`;
 
   const lines = data.value.split('\n');
   let numbers = '';
@@ -45,9 +47,7 @@ function highlightUtil(str, options = {}) {
 
   let result = `<figure class="highlight${data.language ? ` ${data.language}` : ''}">`;
 
-  if (caption) {
-    result += `<figcaption>${caption}</figcaption>`;
-  }
+  result += figCaption;
 
   result += '<table><tr>';
 

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -185,6 +185,23 @@ describe('highlight', () => {
     validateHtmlAsync(result, done);
   });
 
+  it('caption (wrap: false)', done => {
+    const result = highlight(testString, {
+      gutter: false,
+      wrap: false,
+      caption: 'hello world'
+    });
+
+    result.should.eql([
+      '<pre>',
+      '<figcaption>hello world</figcaption>',
+      '<code class="highlight plain">',
+      entities.encode(testString),
+      '</code></pre>'
+    ].join(''));
+    validateHtmlAsync(result, done);
+  });
+
   it('tab', done => {
     const str = [
       'function fib(i){',


### PR DESCRIPTION
Add codeblock caption/title even when `wrap` is disabled.

\`\`\` js title
console.log('foo');
\`\`\`

https://hexo.io/docs/tag-plugins#Examples-1

```
{% codeblock Array.map %}
array.map(callback[, thisArg])
{% endcodeblock %}
```