### PR TITLE
fix: escapeHTML cannot esacpe numeric character reference correctly

### DIFF
--- a/lib/escape_html.js
+++ b/lib/escape_html.js
@@ -19,7 +19,7 @@ function escapeHTML(str) {
   str = unescapeHTML(str);
 
   // http://stackoverflow.com/a/12034334
-  return str.replace(/[&<>"'`/=]/g, a => htmlEntityMap[a]);
+  return str.replace(/[<>"'`/=]/g, a => htmlEntityMap[a]).replace(/&(?!#(\d{1,4}|x[a-zA-Z0-9]{1,4});)/, '&amp;');
 }
 
 module.exports = escapeHTML;

--- a/lib/escape_html.js
+++ b/lib/escape_html.js
@@ -19,7 +19,7 @@ function escapeHTML(str) {
   str = unescapeHTML(str);
 
   // http://stackoverflow.com/a/12034334
-  return str.replace(/[<>"'`/=]/g, a => htmlEntityMap[a]).replace(/&(?!#(\d{1,4}|x[a-zA-Z0-9]{1,4});)/, '&amp;');
+  return str.replace(/&(?!#(\d{1,4}|x[a-zA-Z0-9]{1,4});)/, '&amp;').replace(/[<>"'`/=]/g, a => htmlEntityMap[a]);
 }
 
 module.exports = escapeHTML;


### PR DESCRIPTION
The old implementation will escape '&' in any numeric character reference except 
```text
', `, /, =
```

For example if someone using some language with Unicode character, e.g.  Σ (`&#931;`) will escape as `&amp;#931;`, then display as `&#931;` not `Σ`

(First I thought it's a fault of theme-next in theme-next/hexo-theme-next#1521)