### PR TITLE
refactor(encode/decode_url): replace decodeURI with unescape

### DIFF
--- a/lib/decode_url.js
+++ b/lib/decode_url.js
@@ -1,14 +1,7 @@
 'use strict';
 
 const { parse, format } = require('url');
-
-const safeDecodeURI = str => {
-  try {
-    return decodeURI(str);
-  } catch (err) {
-    return str;
-  }
-};
+const { unescape } = require('querystring');
 
 const decodeURL = str => {
   if (parse(str).protocol) {
@@ -18,10 +11,10 @@ const decodeURL = str => {
     if (parsed.origin === 'null') return str;
 
     const url = format(parsed, { unicode: true });
-    return safeDecodeURI(url);
+    return unescape(url);
   }
 
-  return safeDecodeURI(str);
+  return unescape(str);
 };
 
 module.exports = decodeURL;

--- a/lib/encode_url.js
+++ b/lib/encode_url.js
@@ -1,14 +1,7 @@
 'use strict';
 
 const { parse, format } = require('url');
-
-const safeDecodeURI = str => {
-  try {
-    return decodeURI(str);
-  } catch (err) {
-    return str;
-  }
-};
+const { unescape } = require('querystring');
 
 const encodeURL = str => {
   if (parse(str).protocol) {
@@ -17,12 +10,12 @@ const encodeURL = str => {
     // Exit if input is a data url
     if (parsed.origin === 'null') return str;
 
-    parsed.search = encodeURI(safeDecodeURI(parsed.search));
+    parsed.search = encodeURI(unescape(parsed.search));
     // preserve IDN
     return format(parsed, { unicode: true });
   }
 
-  return encodeURI(safeDecodeURI(str));
+  return encodeURI(unescape(str));
 };
 
 module.exports = encodeURL;


### PR DESCRIPTION
[`unescape()`](https://nodejs.org/api/querystring.html#querystring_querystring_unescape_str) is a safer alternative that doesn't throw error when encounter malformed URI.