### PR TITLE
feat(highlight): add prism-themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "deepmerge": "^4.2.2",
     "highlight.js": "^10.0.0",
     "htmlparser2": "^4.0.0",
+    "prism-themes": "^1.4.0",
     "prismjs": "^1.17.1",
     "strip-indent": "^3.0.0",
     "striptags": "^3.1.1"


### PR DESCRIPTION
`prism-themes` lists a selection of additional themes for the Prism syntax highlighting library: https://github.com/PrismJS/prism-themes/tree/master/themes
Including this package in `dependencies` will make it easier for theme developers to use code highlight style from `node_modules`. e.g.
```scss
@import '../node_modules/highlight.js/styles/a11y-dark.css';
@import '../node_modules/prismjs/themes/prism-coy.css';
@import '../node_modules/prism-themes/themes/prism-a11y-dark.css';
```