### PR TITLE
fix(spawn): support string argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,13 @@ Option | Description | Default
 `encoding` | Sets the encoding of the output string | `utf8`
 
 ``` js
-spawn('cat', 'test.txt').then(function(content){
+spawn('cat', 'test.txt').then((content) => {
+  console.log(content);
+});
+
+// $ cd "/target/folder"
+// $ cat "foo.txt" "bar.txt"
+spawn('cat', ['foo.txt', 'bar.txt'], { cwd: '/target/folder' }).then((content) => {
   console.log(content);
 });
 ```

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -4,17 +4,15 @@ const spawn = require('cross-spawn');
 const Promise = require('bluebird');
 const CacheStream = require('./cache_stream');
 
-function promiseSpawn(command, args = [], options) {
+function promiseSpawn(command, args = [], options = {}) {
   if (!command) throw new TypeError('command is required!');
 
   if (typeof args === 'string') args = [args];
 
-  if (!options && !Array.isArray(args)) {
+  if (!Array.isArray(args)) {
     options = args;
     args = [];
   }
-
-  options = options || {};
 
   return new Promise((resolve, reject) => {
     const task = spawn(command, args, options);

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -7,6 +7,8 @@ const CacheStream = require('./cache_stream');
 function promiseSpawn(command, args = [], options) {
   if (!command) throw new TypeError('command is required!');
 
+  if (typeof args === 'string') args = [args];
+
   if (!options && !Array.isArray(args)) {
     options = args;
     args = [];

--- a/test/spawn.spec.js
+++ b/test/spawn.spec.js
@@ -24,6 +24,8 @@ describe('spawn', () => {
 
   it('default', () => spawn(catCommand, [fixturePath]).should.become(fixture));
 
+  it('default - string', () => spawn(catCommand, fixturePath).should.become(fixture));
+
   it('command is required', () => {
     spawn.should.throw('command is required!');
   });

--- a/test/spawn.spec.js
+++ b/test/spawn.spec.js
@@ -26,6 +26,26 @@ describe('spawn', () => {
 
   it('default - string', () => spawn(catCommand, fixturePath).should.become(fixture));
 
+  it('default - empty argument and options', async () => {
+    if (isWindows) {
+      const out = await spawn('ver');
+      out.trim().startsWith('Microsoft Windows').should.eql(true);
+    } else {
+      const out = await spawn('uname');
+      out.trim().should.eql('Linux');
+    }
+  });
+
+  it('default - options and empty argument', async () => {
+    if (isWindows) {
+      const out = await spawn('chdir', { cwd: __dirname });
+      out.trim().should.eql(__dirname);
+    } else {
+      const out = await spawn('pwd', { cwd: __dirname });
+      out.trim().should.eql(__dirname);
+    }
+  });
+
   it('command is required', () => {
     spawn.should.throw('command is required!');
   });


### PR DESCRIPTION
current example uses string argument, so `spawn()` should support it.
also add array argument and options example.