### PR TITLE
feat(highlight): support 'tab' & 'mark' when wrap is disabled

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -32,8 +32,6 @@ function highlightUtil(str, options = {}) {
 
   const figCaption = caption ? `<figcaption>${caption}</figcaption>` : '';
 
-  if (!wrap) return `<pre>${figCaption}<code class="${classNames}">${data.value}</code></pre>`;
-
   const lines = data.value.split('\n');
   let numbers = '';
   let content = '';
@@ -42,7 +40,13 @@ function highlightUtil(str, options = {}) {
     let line = lines[i];
     if (tab) line = replaceTabs(line, tab);
     numbers += `<span class="line">${Number(firstLine) + i}</span><br>`;
-    content += formatLine(line, Number(firstLine) + i, mark, options);
+    content += formatLine(line, Number(firstLine) + i, mark, options, wrap);
+  }
+
+  if (!wrap) {
+    // if original content has one trailing newline, replace it only once, else remove all trailing newlines
+    content = /\r?\n$/.test(data.value) ? content.replace(/\n$/, '') : content.trimEnd();
+    return `<pre>${figCaption}<code class="${classNames}">${content}</code></pre>`;
   }
 
   let result = `<figure class="highlight${data.language ? ` ${data.language}` : ''}">`;
@@ -61,8 +65,9 @@ function highlightUtil(str, options = {}) {
   return result;
 }
 
-function formatLine(line, lineno, marked, options) {
-  const useHljs = options.hljs || false;
+function formatLine(line, lineno, marked, options, wrap) {
+  const useHljs = (options.hljs || false) || !wrap;
+  const br = wrap ? '<br>' : '\n';
   let res = useHljs ? '' : '<span class="line';
   if (marked.includes(lineno)) {
     // Handle marked lines.
@@ -71,7 +76,7 @@ function formatLine(line, lineno, marked, options) {
     res += useHljs ? line : `">${line}</span>`;
   }
 
-  res += '<br>';
+  res += br;
   return res;
 }
 

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -133,6 +133,28 @@ describe('highlight', () => {
     validateHtmlAsync(result, done);
   });
 
+  it('wrap: false (with mark)', done => {
+    const result = highlight(testString, {gutter: false, wrap: false, hljs: true, lang: 'json', mark: '1'});
+    hljs.configure({classPrefix: 'hljs-'});
+    result.should.eql([
+      '<pre><code class="hljs json">',
+      hljs.highlight('json', testString).value.replace('{', '<mark>{</mark>'),
+      '</code></pre>'
+    ].join(''));
+    validateHtmlAsync(result, done);
+  });
+
+  it('wrap: false (retain trailing newline)', done => {
+    const result = highlight(testString + '\n', {gutter: false, wrap: false, hljs: true, lang: 'json'});
+    hljs.configure({classPrefix: 'hljs-'});
+    result.should.eql([
+      '<pre><code class="hljs json">',
+      hljs.highlight('json', testString).value,
+      '\n</code></pre>'
+    ].join(''));
+    validateHtmlAsync(result, done);
+  });
+
   it('firstLine', done => {
     const result = highlight(testString, {firstLine: 3});
     assertResult(result, gutter(3, 6), code(testString));
@@ -203,6 +225,7 @@ describe('highlight', () => {
   });
 
   it('tab', done => {
+    const spaces = '  ';
     const str = [
       'function fib(i){',
       '\tif (i <= 1) return i;',
@@ -210,13 +233,26 @@ describe('highlight', () => {
       '}'
     ].join('\n');
 
-    const result = highlight(str, {tab: '  ', lang: 'js'});
+    const result = highlight(str, {tab: spaces, lang: 'js'});
 
     result.should.eql([
       '<figure class="highlight js"><table><tr>',
       gutter(1, 4),
-      code(str.replace(/\t/g, '  '), 'js'),
+      code(str.replace(/\t/g, spaces), 'js'),
       end
+    ].join(''));
+    validateHtmlAsync(result, done);
+  });
+
+  it('tab with wrap:false', done => {
+    const spaces = '  ';
+    const result = highlight('\t' + testString, {gutter: false, wrap: false, hljs: true, lang: 'json', tab: spaces});
+    hljs.configure({classPrefix: 'hljs-'});
+    result.should.eql([
+      '<pre><code class="hljs json">',
+      spaces,
+      hljs.highlight('json', testString).value,
+      '</code></pre>'
     ].join(''));
     validateHtmlAsync(result, done);
   });


### PR DESCRIPTION
``` yml
# _config.yml
highlight:
  tab_replace: '  '
  wrap: false
```

``` js
{% codeblock lang:js mark:2,5 %}
const input = [
  { name: 'lorem', item: 'ipsum' },
  { name: 'per', item: 'doming' },
  { name: 'dolor', item: 'lorem' },
  { name: 'usu', item: 'pericula' }
]
{% endcodeblock %}
```

![wrap](https://user-images.githubusercontent.com/43627182/88916738-c254de00-d2a5-11ea-9507-58a4da389da2.jpg)
