### PR TITLE
feat(url_for): convert backward to forward slash

### DIFF
--- a/lib/url_for.js
+++ b/lib/url_for.js
@@ -39,7 +39,7 @@ function urlForHelper(path = '/', options) {
     }
 
     // Prepend root path
-    path = encodeURL((root + path).replace(/\/{2,}/g, '/'));
+    path = encodeURL((root + path).replace(/\\/g, '/').replace(/\/{2,}/g, '/'));
 
     path = prettyUrls(path, prettyUrlsOptions);
 

--- a/test/url_for.spec.js
+++ b/test/url_for.spec.js
@@ -140,4 +140,13 @@ describe('url_for', () => {
       urlFor(url).should.eql(url);
     });
   });
+
+  it('backward to forward slash', () => {
+    ctx.config.root = '/';
+    urlFor('\\lorem\\ipsum').should.eql('/lorem/ipsum');
+
+    ctx.config.root = '/blog/';
+    urlFor('\\lorem\\ipsum').should.eql('/blog/lorem/ipsum');
+  });
+
 });


### PR DESCRIPTION
to deal with Windows path, see https://github.com/hexojs/hexo/pull/4479/files#r470968350

`url_for()` deals with relative URLs, which should never have backward slash.

`full_url_for()` doesn't need to update because `encodeURL()` already have conversion in place (via URL API).