### PR TITLE
fix(highlight): use <div> when wrap is disabled

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -30,7 +30,6 @@ function highlightUtil(str, options = {}) {
   const before = useHljs ? `<pre><code class="${classNames}">` : '<pre>';
   const after = useHljs ? '</code></pre>' : '</pre>';
 
-  const figCaption = caption ? `<figcaption>${caption}</figcaption>` : '';
 
   const lines = data.value.split('\n');
   let numbers = '';
@@ -43,15 +42,22 @@ function highlightUtil(str, options = {}) {
     content += formatLine(line, Number(firstLine) + i, mark, options, wrap);
   }
 
+  let codeCaption = '';
+
+  if (caption) {
+    if (wrap) codeCaption = `<figcaption>${caption}</figcaption>`;
+    else codeCaption = `<div>${caption}</div>`;
+  }
+
   if (!wrap) {
     // if original content has one trailing newline, replace it only once, else remove all trailing newlines
     content = /\r?\n$/.test(data.value) ? content.replace(/\n$/, '') : content.trimEnd();
-    return `<pre>${figCaption}<code class="${classNames}">${content}</code></pre>`;
+    return `<pre>${codeCaption}<code class="${classNames}">${content}</code></pre>`;
   }
 
   let result = `<figure class="highlight${data.language ? ` ${data.language}` : ''}">`;
 
-  result += figCaption;
+  result += codeCaption;
 
   result += '<table><tr>';
 

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -45,7 +45,7 @@ function highlightUtil(str, options = {}) {
   let codeCaption = '';
 
   if (caption) {
-    codeCaption = wrap ? `<figcaption>${caption}</figcaption>` : `<div>${caption}</div>`;
+    codeCaption = wrap ? `<figcaption>${caption}</figcaption>` : `<div class="caption">${caption}</div>`;
   }
 
   if (!wrap) {

--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -45,8 +45,7 @@ function highlightUtil(str, options = {}) {
   let codeCaption = '';
 
   if (caption) {
-    if (wrap) codeCaption = `<figcaption>${caption}</figcaption>`;
-    else codeCaption = `<div>${caption}</div>`;
+    codeCaption = wrap ? `<figcaption>${caption}</figcaption>` : `<div>${caption}</div>`;
   }
 
   if (!wrap) {

--- a/lib/prism.js
+++ b/lib/prism.js
@@ -98,7 +98,7 @@ function PrismUtil(str, options = {}) {
 
   if (tab) str = replaceTabs(str, tab);
 
-  const codeCaption = caption ? `<div>${caption}</div>` : '';
+  const codeCaption = caption ? `<div class="caption">${caption}</div>` : '';
 
   const startTag = `<pre class="${preTagClassArr.join(' ')}"${preTagAttr}>${codeCaption}<code class="language-${language}">`;
   const endTag = '</code></pre>';

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -194,12 +194,13 @@ describe('highlight', () => {
   // it('don\'t highlight if parse failed'); missing-unit-test
 
   it('caption', done => {
+    const caption = 'hello world';
     const result = highlight(testString, {
-      caption: 'hello world'
+      caption
     });
 
     result.should.eql([
-      '<figure class="highlight plain"><figcaption>hello world</figcaption><table><tr>',
+      `<figure class="highlight plain"><figcaption>${caption}</figcaption><table><tr>`,
       gutter(1, 4),
       code(testString),
       end
@@ -208,15 +209,16 @@ describe('highlight', () => {
   });
 
   it('caption (wrap: false)', done => {
+    const caption = 'hello world';
     const result = highlight(testString, {
       gutter: false,
       wrap: false,
-      caption: 'hello world'
+      caption
     });
 
     result.should.eql([
       '<pre>',
-      '<figcaption>hello world</figcaption>',
+      `<div>${caption}</div>`,
       '<code class="highlight plain">',
       entities.encode(testString),
       '</code></pre>'

--- a/test/highlight.spec.js
+++ b/test/highlight.spec.js
@@ -218,7 +218,7 @@ describe('highlight', () => {
 
     result.should.eql([
       '<pre>',
-      `<div>${caption}</div>`,
+      `<div class="caption">${caption}</div>`,
       '<code class="highlight plain">',
       entities.encode(testString),
       '</code></pre>'

--- a/test/prism.spec.js
+++ b/test/prism.spec.js
@@ -330,7 +330,7 @@ describe('prismHighlight', () => {
     const caption = 'foo';
     const result = prismHighlight(input, { caption });
 
-    result.should.contains('<div>' + caption + '</div>');
+    result.should.contains('<div class="caption">' + caption + '</div>');
 
     validateHtmlAsync(result, done);
   });


### PR DESCRIPTION
- BREAKING CHANGE: `<figcaption>` is replaced with `<div>` when wrap is disabled
- https://github.com/hexojs/hexo-util/pull/227#issuecomment-673347477

Affects users of following config:

``` yml
# _config.yml
highlight:
  line_number: false
  wrap: false

# or
prismjs:
  enable: true
```

New rendered html:

``` html
<pre>
  <div class="caption">
    caption here
  </div>
  <code>codeblock</code>
<pre>
```

suggested css:

``` css
pre div.caption {
  font-size: 0.9em;
  color: #888;
}

pre div.caption a {
  float: right;
}
```