### PR TITLE
feat(cache): add keyStringify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 Utilities for [Hexo].
 
 ## Table of contents
-
 - [Installation](#installation)
 - [Usage](#usage)
 - [Cache](#cache)
@@ -75,7 +74,7 @@ cache.has('foo');
 cache.has('bar');
 // false
 
-// apply(key. value)
+// apply(key, value, options)
 cache.apply('baz', () => 123);
 // 123
 cache.apply('baz', () => 456);
@@ -84,6 +83,12 @@ cache.apply('qux', 456);
 // 456
 cache.apply('qux', '789');
 // 456
+cache.apply({ a: 1, b: 2 }, 123, { keyStringify: true })
+// 123
+cache.apply({ a: 1, b: 2 }, 456, { keyStringify: true })
+// 123
+cache.apply({ b: 2, a: 1 }, 789, { keyStringify: true })
+// 789
 
 // size()
 cache.size();

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,5 +1,11 @@
 'use strict';
 
+const { createSha1Hash } = require('./hash');
+
+function md5(str = '') {
+  return createSha1Hash('md5').update(str).digest('hex');
+}
+
 module.exports = class Cache {
   constructor() {
     this.cache = new Map();
@@ -21,7 +27,13 @@ module.exports = class Cache {
     this.cache.delete(id);
   }
 
-  apply(id, value) {
+  apply(id, value, options = { keyStringify: false }) {
+    if (options.keyStringify) {
+      try {
+        id = md5(JSON.stringify(id));
+      } catch { }
+    }
+
     if (this.has(id)) return this.get(id);
 
     if (typeof value === 'function') value = value();

--- a/test/cache.spec.js
+++ b/test/cache.spec.js
@@ -33,12 +33,20 @@ describe('Cache', () => {
     cache.apply('baz', () => 456).should.eql(123);
   });
 
+  it('apply - keyStringify', () => {
+    cache.apply({ a: 1, b: 2 }, 123, { keyStringify: true }).should.eql(123);
+    cache.apply({ a: 1, b: 2 }, 456, { keyStringify: true }).should.eql(123);
+    cache.apply({ b: 2, a: 1 }, 789, { keyStringify: true }).should.eql(789);
+  });
+
   it('dump', () => {
     cache.dump().should.eql({
       'bar': 123,
       'baz': 123,
       'foo': 123,
-      'foobar': 456
+      'foobar': 456,
+      'bdf293b90add9094d1dcb0dc43929211612434ba': 789,
+      '4acc71e0547112eb432f0a36fb1924c4a738cb49': 123
     });
   });
 


### PR DESCRIPTION
With `keyStringify` option, we could use a plain object as a cache key, and invalidate the cache when the object is changed.