### PR TITLE
refactor(cache): remove Object.fromEntries ponyfill

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -39,19 +39,6 @@ module.exports = class Cache {
   }
 
   dump() {
-    // Object#fromEntries supported since Node.js 12
-
-    // eslint-disable-next-line node/no-unsupported-features/es-builtins
-    if (typeof Object.fromEntries === 'function') {
-      // eslint-disable-next-line node/no-unsupported-features/es-builtins
-      return Object.fromEntries(this.cache);
-    }
-
-    // FIXME: A polyfill for Node.js 10 & 11
-    const obj = {};
-    this.cache.forEach((v, k) => {
-      obj[k] = v;
-    });
-    return obj;
+    return Object.fromEntries(this.cache);
   }
 };


### PR DESCRIPTION
As Node.js 10 has been dropped.