### PR TITLE
refactor: use `textContent` instead of `getText`

### DIFF
--- a/lib/toc_obj.js
+++ b/lib/toc_obj.js
@@ -41,7 +41,7 @@ function tocObj(str, options = {}) {
     const unnumbered = isUnnumbered(el);
     let text = '';
     for (const element of el.children) {
-      const elText = DomUtils.getText(element);
+      const elText = DomUtils.textContent(element);
       // Skip permalink symbol wrapped in <a>
       // permalink is a single non-word character, word = [a-Z0-9]
       // permalink may be wrapped in whitespace(s)
@@ -49,7 +49,7 @@ function tocObj(str, options = {}) {
         text += escapeHTML(elText);
       }
     }
-    if (!text) text = escapeHTML(DomUtils.getText(el));
+    if (!text) text = escapeHTML(DomUtils.textContent(el));
 
     const res = { text, id, level };
     if (unnumbered) res.unnumbered = true;


### PR DESCRIPTION
`getText` function is duplicated in [domutils@v2.7.0](https://github.com/fb55/domutils/releases/tag/v2.7.0). Use `textContent` instead of it.

> https://github.com/fb55/domutils/commit/2cf08148dbe02f4c858b78efce34d07fb6f4b5bd#diff-8cdb5d3024cfa8506c5bb07b6975d6c983078bc51c7c166cf9550f47de24027aR36