### PR TITLE
refactor(hash): remove the export of HashStream

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,6 @@ exports.escapeRegExp = require('./escape_regexp');
 exports.full_url_for = require('./full_url_for');
 exports.gravatar = require('./gravatar');
 exports.hash = hash.hash;
-exports.HashStream = hash.HashStream;
 exports.highlight = require('./highlight');
 exports.htmlTag = require('./html_tag');
 exports.isExternalLink = require('./is_external_link');


### PR DESCRIPTION
[`HashStream` has long been drop](https://github.com/hexojs/hexo-util/pull/198), and we should remove the export for it.