### PR TITLE
fix: Typographical problem of too long lines after code highlighting

### DIFF
--- a/lib/highlight.js
+++ b/lib/highlight.js
@@ -54,7 +54,7 @@ function highlightUtil(str, options = {}) {
     return `<pre>${codeCaption}<code class="${classNames}"${languageAttr && lang ? ` data-language="${lang}"` : ''}>${content}</code></pre>`;
   }
 
-  let result = `<figure class="highlight${data.language ? ` ${data.language}` : ''}"${languageAttr && lang ? ` data-language="${lang}"` : ''}>`;
+  let result = `<figure class="highlight${data.language ? ` ${data.language}` : ''}"${languageAttr && lang ? ` data-language="${lang}"` : ''}><div class="container">`;
 
   result += codeCaption;
 
@@ -65,7 +65,7 @@ function highlightUtil(str, options = {}) {
   }
 
   result += `<td class="code">${before}${content}${after}</td>`;
-  result += '</tr></table></figure>';
+  result += '</tr></table></div></figure>';
 
   return result;
 }


### PR DESCRIPTION
The original implementation would have placed a table to hold the code inside the 'figure' tag
<img width="464" alt="截屏2022-11-03 上午12 22 02" src="https://user-images.githubusercontent.com/54500106/199544704-e38550dd-3ce2-4e68-b8b2-f5f8b5823f54.png">
I implemented a code type identifier by placing the ::after pseudo-element in this 'figure'
<img width="713" alt="截屏2022-11-03 上午12 24 30" src="https://user-images.githubusercontent.com/54500106/199545521-c7110522-caac-4903-942e-9c6931d8bf4e.png">
I set 'overflow: scroll' to the <figure> element, so if scrolling occurs, the pseudo-element I set will scroll with it
<img width="713" alt="截屏2022-11-03 上午12 28 50" src="https://user-images.githubusercontent.com/54500106/199546479-7eb9ae47-5e37-4d09-96b8-2330678aeb34.png">
The solution is to wrap the table with a div that has 'overflow: scroll', where the language indicator is correctly positioned
<img width="1282" alt="截屏2022-11-03 上午1 01 57" src="https://user-images.githubusercontent.com/54500106/199554231-74e48aa1-76ea-4895-b8d1-4dcf050b691a.png">


