### PR TITLE
fix TS2550 - add lib es2020, es2019

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "mocha --require ts-node/register",
     "test-cov": "nyc --reporter=lcovonly npm run test",
     "build:highlight": "node scripts/build_highlight_alias.js",
-    "prepare": "npm run build:highlight"
+    "postinstall": "npm run build:highlight"
   },
   "files": [
     "dist/**",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.1",
   "description": "Utilities for Hexo.",
   "main": "dist/index",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "prepublishOnly": "npm install && npm run clean && npm run build",
     "build": "tsc -b",
@@ -20,7 +21,6 @@
     "scripts/",
     "highlight_alias.json"
   ],
-  "types": "./dist/index.d.ts",
   "repository": "hexojs/hexo-util",
   "homepage": "https://hexo.io/",
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "types": [
       "node"
-    ]
+    ],
+    "lib": ["ES2020", "ES2019"]
   },
   "include": [
     "lib/index.ts"


### PR DESCRIPTION
[refactor: fix TS2550 - add lib es2020, es2019](https://github.com/hexojs/hexo-util/commit/2960b2173efbe2f2343237d557e65ee8d3fddb82)

Property 'fromEntries' does not exist on type 'ObjectConstructor'

Property 'matchAll' does not exist on type 'string'

fixed failure build in node `14` with typescript `5`