### PR TITLE
chore(dependabot): ignore `@types/node` update and reduce PR from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,9 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
+  ignore:
+    - dependency-name: "@types/node"
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]
+  open-pull-requests-limit: 3


### PR DESCRIPTION
Please see: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#creating-ignore-conditions-from-dependabot-ignore