### PR TITLE
build(tsc): fix tsconfig for `tsc -b --watch`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,15 +6,9 @@
     "outDir": "dist",
     "declaration": true,
     "esModuleInterop": true,
-    "types": [
-      "node"
-    ],
+    "types": ["node"],
     "lib": ["ES2020", "ES2019"]
   },
-  "include": [
-    "lib/index.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["lib/**.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION

if use `"include": ["lib/index.ts"]`, `tsc -b --watch` can't detect others files in `lib/` and rebuild.