### PR TITLE
chore: update `repository` key from a string to an object in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "scripts/",
     "highlight_alias.json"
   ],
-  "repository": "hexojs/hexo-util",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hexojs/hexo-util.git"
+  },
   "homepage": "https://hexo.io/",
   "keywords": [
     "hexo",


### PR DESCRIPTION
## Why?

As is the title.

See: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository

## Log

Warning log when I run `npm publish --dry-run`.

```
$ npm publish --dry-run
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/hexojs/hexo-deployer-ftpsync.git"
npm notice
```
-----

Thanks :)