### PR TITLE
fix: ensure PrismJS works in ESM builds and aliases are resolved

### DIFF
--- a/lib/prism.ts
+++ b/lib/prism.ts
@@ -1,23 +1,24 @@
+import PrismCore from 'prismjs';
+import prismLoadLanguages from 'prismjs/components/index.js';
 import stripIndent from 'strip-indent';
-import prismLoadLanguages from 'prismjs/components/';
 
 let Prism: typeof import('prismjs') | undefined;
 
-// https://github.com/PrismJS/prism/issues/2145
-import prismComponents from 'prismjs/components';
-
-const prismAlias = Object.entries(prismComponents.languages).reduce((acc, [key, value]) => {
-  if (value.alias) {
-    if (Array.isArray(value.alias)) {
-      value.alias.forEach(alias => (acc[alias] = key));
-    } else if (typeof value.alias === 'string') {
-      acc[value.alias] = key;
+const prismAlias = Object.entries(PrismCore.languages).reduce((acc, [key, value]) => {
+  if (value && typeof value === 'object' && 'alias' in value) {
+    const alias = (value as { alias?: string | string[] }).alias;
+    if (alias) {
+      if (Array.isArray(alias)) {
+        alias.forEach(a => (acc[a] = key));
+      } else if (typeof alias === 'string') {
+        acc[alias] = key;
+      }
     }
   }
   return acc;
-}, {});
+}, {} as Record<string, string>);
 
-const prismSupportedLanguages = Object.keys(prismComponents.languages).concat(Object.keys(prismAlias));
+const prismSupportedLanguages = Object.keys(PrismCore.languages).concat(Object.keys(prismAlias));
 
 import escapeHTML from './escape_html';
 
@@ -87,9 +88,35 @@ function PrismUtil(str: string, options: Options = {}) {
   }
 
   // To be consistent with highlight.js
+  // Normalize language aliases to canonical Prism names
   let language = lang === 'plaintext' || lang === 'none' ? 'none' : lang;
-
+  // Manual alias mapping for common cases
+  const manualAlias: Record<string, string> = {
+    js: 'javascript',
+    ts: 'typescript',
+    py: 'python',
+    rb: 'ruby',
+    sh: 'bash',
+    html: 'markup',
+    md: 'markdown',
+    csharp: 'cs',
+    shell: 'bash',
+    yml: 'yaml',
+    vue: 'markup',
+    plaintext: 'none',
+    none: 'none'
+  };
+  if (manualAlias[language]) language = manualAlias[language];
   if (prismAlias[language]) language = prismAlias[language];
+
+  // Ensure Prism loads the language if not loaded
+  if (language !== 'none' && PrismCore && !PrismCore.languages[language]) {
+    try {
+      prismLoadLanguages(language);
+    } catch (e) {
+      // ignore
+    }
+  }
 
   const preTagClassArr = [];
   const preTagAttrArr = [];
@@ -127,10 +154,25 @@ function PrismUtil(str: string, options: Options = {}) {
 
   let parsedCode = '';
 
-  if (language === 'none' || !isPreprocess) {
-    parsedCode = escapeHTML(str);
-  } else {
+  // Always use Prism for supported languages, even if not loaded yet
+  if (language !== 'none' && isPreprocess && PrismCore.languages[language]) {
     parsedCode = prismHighlight(str, language);
+  } else if (language !== 'none' && isPreprocess && Prism && Prism.languages[language]) {
+    parsedCode = prismHighlight(str, language);
+  } else if (language !== 'none' && isPreprocess) {
+    // Try to load language and highlight
+    try {
+      prismLoadLanguages(language);
+      if (PrismCore.languages[language]) {
+        parsedCode = prismHighlight(str, language);
+      } else {
+        parsedCode = escapeHTML(str);
+      }
+    } catch (e) {
+      parsedCode = escapeHTML(str);
+    }
+  } else {
+    parsedCode = escapeHTML(str);
   }
 
   // lineNumberUtil() should be used only under preprocess mode


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [ ] Add test cases for the changes.
- [x] Passed the CI test.

## Description

This PR resolves PrismJS compatibility issues in ESM environments and improves language alias handling. Key changes:

### ✅ Fixes
- Replaces use of `prismjs/components` (CJS-only) with direct ESM-compatible imports (`prismjs/components/index.js`).
- Uses `PrismCore.languages` instead of relying on CJS metadata for language definitions and aliases.
- Adds fallback logic to dynamically load missing languages using `prismLoadLanguages(...)`.

### 🧠 Enhancements
- Adds a `manualAlias` mapping for common aliases like `js` → `javascript`, `sh` → `bash`, etc.
- Consolidates alias resolution from both `manualAlias` and `Prism.languages.alias`.
- Ensures Prism highlighting still works gracefully even when a language is not preloaded.

## Additional information
- Compatible with both ESM and CJS build setups.
- More robust handling of language codes and aliases, reducing false negatives and errors.
- Better runtime resilience in rendering code blocks.