### PR TITLE
fix(linter): add build step before linting process

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,6 +12,8 @@ jobs:
           node-version: 'lts/*'
       - name: Install Dependencies
         run: npm install
+      - name: Build
+        run: npm run build
       - name: Lint
         run: |
           npm run eslint


### PR DESCRIPTION


<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [ ] Add test cases for the changes.
- [x] Passed the CI test.

## Description

- fixed `../dist` folder not exist while linting
